### PR TITLE
Add `trial` and `event` schemas (unblocks the data-model reference-only redesign)

### DIFF
--- a/event/CHANGELOG.md
+++ b/event/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — Behaverse Event Schema
+
+All notable changes to the event schema are documented here. CalVer `vYY.MMDD`.
+
+## [26.0608] - 2026-06-08
+
+### Added
+
+- Initial event schema in `behaverse/schemas`: an xAPI-style envelope (`actor`/`verb`/`object`) plus the canonical `bdm:` vocabulary — 24 verbs, 15 object types, 5 actor types.
+- `field-definitions.yaml` (source: 11 envelope fields + the vocabulary) and generated `field-definitions.json` (the render contract).
+- `schema.json` (JSON Schema Draft 2020-12, Event / EventBatch), `context.jsonld`, and `examples/` (minimal event + PHQ-9 / N-back / kitchensink batches).
+- `scripts/generate.py` to regenerate `field-definitions.json`.
+
+### Changed
+
+- Relocated from the Behaverse questionnaire project (`schemas/events` v26.0605) and **canonicalized to `event` (singular)**: `$id` and namespace rewritten from `…/schemas/events/v26.0605` to `…/schemas/event/v26.0608`.
+- Field named `actor` (not `agent`) from the outset — BDM deviation D5.
+
+### Notes
+
+- Realizes BDM deviations D4 (canonical events vocabulary), D5 (`agent` → `actor`), D6 (scoping hierarchy).
+- The ~50 `bdm:*` extension keys' per-key shape contracts (from the source design note) are a follow-up to relocate here.

--- a/event/README.md
+++ b/event/README.md
@@ -1,0 +1,42 @@
+# Behaverse Event Schema (WIP)
+
+**Version:** v26.0608
+**Namespace:** `https://behaverse.org/schemas/event#`
+**Source of truth:** [`field-definitions.yaml`](field-definitions.yaml) (envelope + vocabulary) — run `uv run scripts/generate.py`. [`schema.json`](schema.json) is the validation contract.
+
+## Overview
+
+Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style envelope (**actor / verb / object**) carrying a single canonical `bdm:` vocabulary, so one set of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG, …) are referenced via `attachments`, not inlined. It is the *Events* layer of the Behaverse Data Model (BDM); see **[behaverse.org/data-model](https://behaverse.org/data-model)**.
+
+## Vocabulary at a glance
+
+- **24 verbs** across 6 layers: RuntimeInstance lifecycle (7), presentation (1 polymorphic), agent interaction (10), system (3), recording (2), navigation (1).
+- **15 object types:** RuntimeInstance, Screen, Panel, Stimulus, Option, Trial, UIComponent, Window, Feedback, ConsentForm, Consent, Recording, Timer, Scorer, LocaleSwitch.
+- **5 actor types:** Agent, Group, Engine, Orchestrator, Researcher.
+- **`bdm:*` extension keys** (open-by-design) carry response data, the scoping hierarchy, environment, and interaction-specific payloads under `result.extensions` / `context.extensions`.
+
+## Scoping hierarchy
+
+Events are positioned in a five-level hierarchy carried in `context.extensions`:
+`session → activity → RuntimeInstance → block → trial`. The Activity-vs-RuntimeInstance distinction separates *what was planned* from *a specific execution* (restarts produce distinct RuntimeInstances).
+
+## Artifacts
+
+| File | Status | Purpose |
+|------|--------|---------|
+| [`field-definitions.yaml`](field-definitions.yaml) | ✅ | Source of truth (envelope + vocabulary). |
+| [`field-definitions.json`](field-definitions.json) | ✅ generated | Render contract consumed by `behaverse/data-model` and the docs site. |
+| [`schema.json`](schema.json) | ✅ | JSON Schema (Draft 2020-12) for validation. |
+| [`context.jsonld`](context.jsonld) | ✅ | JSON-LD context (`bdm:`, `xapi:`, `schema:`, `as2:`). |
+| [`examples/`](examples/) | ✅ | Minimal event + PHQ-9 / N-back / kitchensink event batches. |
+
+## Provenance & follow-ups
+
+Relocated from the Behaverse questionnaire project (`schemas/events`, v26.0605), **canonicalized to `event` (singular)** to match `trial` and the BDM convention. Realizes BDM deviations **D4** (this vocabulary), **D5** (`agent` → `actor`, applied), and **D6** (the scoping hierarchy).
+
+- The ~50 `bdm:*` extension keys and their per-key shape contracts are documented in the source design note (`05e_events_vocabulary.md`) and should be relocated into this README or a `vocabulary/` resource.
+- `result`/`context` are intentionally `additionalProperties: true` with `bdm:*`-prefixed extension keys; a tighter per-verb result contract is a follow-up.
+
+## Versioning
+
+CalVer `vYY.MMDD`. See the repo-wide [`VERSIONING.md`](../VERSIONING.md).

--- a/event/context.jsonld
+++ b/event/context.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab":     "https://behaverse.org/schemas/event#",
+    "bdm":        "https://behaverse.org/data-model/vocab/",
+    "xapi":       "https://w3id.org/xapi/",
+    "schema":     "http://schema.org/",
+    "as2":        "https://www.w3.org/ns/activitystreams#",
+    "actor":      { "@id": "https://behaverse.org/data-model/vocab/actor" },
+    "verb":       { "@id": "https://behaverse.org/data-model/vocab/verb", "@type": "@id" },
+    "object":     { "@id": "https://behaverse.org/data-model/vocab/object" },
+    "objectType": { "@id": "@type" },
+    "result":     { "@id": "https://behaverse.org/data-model/vocab/result" },
+    "context":    { "@id": "https://behaverse.org/data-model/vocab/context" },
+    "extensions": { "@id": "https://behaverse.org/data-model/vocab/extensions" },
+    "events":     { "@id": "https://behaverse.org/schemas/event#events", "@container": "@list" }
+  }
+}

--- a/event/examples/cognitive_event_stream.json
+++ b/event/examples/cognitive_event_stream.json
@@ -1,0 +1,95 @@
+{
+  "batch_id": "nback_trial_47",
+  "events": [
+    {
+      "timestamp": "2026-06-05T14:35:00.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_started",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_nback_47"
+      },
+      "context": {
+        "extensions": {
+          "bdm:block_index": 2,
+          "bdm:block_type": "test",
+          "bdm:trial_index": "47",
+          "bdm:session_id": "session_nback_001",
+          "bdm:runtime_id": "rt_nback_run1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:35:00.050Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Stimulus",
+        "id": "stimulus_letter_T",
+        "name": "letter_T"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_nback_001",
+          "bdm:trial_index": "47"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:35:00.482Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_001"
+      },
+      "verb": "bdm:key_pressed",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "keyboard"
+      },
+      "result": {
+        "extensions": {
+          "bdm:key": "ArrowLeft",
+          "bdm:key_code": 37
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_nback_001",
+          "bdm:trial_index": "47"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:35:01.050Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_ended",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_nback_47"
+      },
+      "result": {
+        "extensions": {
+          "bdm:response_description": "ArrowLeft",
+          "bdm:response_time": 0.432,
+          "bdm:correct": true,
+          "bdm:response_id": "R_47"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_nback_001",
+          "bdm:trial_index": "47"
+        }
+      }
+    }
+  ]
+}

--- a/event/examples/kitchensink_event_batch.json
+++ b/event/examples/kitchensink_event_batch.json
@@ -1,0 +1,860 @@
+{
+  "batch_id": "kitchensink_all_verbs",
+  "events": [
+    {
+      "timestamp": "2026-06-05T15:00:00.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:initialized",
+      "object": {
+        "objectType": "bdm:RuntimeInstance",
+        "id": "rt_ks_001"
+      },
+      "context": {
+        "extensions": {
+          "bdm:runtime_id": "rt_ks_001",
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:00.200Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:ConsentForm",
+        "id": "consent_form_v1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:00.350Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:got_focus",
+      "object": {
+        "objectType": "bdm:Window",
+        "id": "window_main"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:04.120Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:clicked",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "checkbox_consent_agree"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:04.125Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:selected",
+      "object": {
+        "objectType": "bdm:Option",
+        "id": "opt_consent_yes",
+        "name": "I agree to participate"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:05.800Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:consented",
+      "object": {
+        "objectType": "bdm:Consent",
+        "id": "consent_record_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:consent_text_hash": "sha256-3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b",
+          "bdm:consent_scope": "study_data_collection"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:06.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:started",
+      "object": {
+        "objectType": "bdm:RuntimeInstance",
+        "id": "rt_ks_001"
+      },
+      "context": {
+        "extensions": {
+          "bdm:runtime_id": "rt_ks_001",
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:06.200Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Screen",
+        "id": "screen_instructions",
+        "name": "Task Instructions"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:runtime_id": "rt_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:15.500Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:navigated",
+      "object": {
+        "objectType": "bdm:Screen",
+        "id": "screen_test_block_1",
+        "name": "Test Block 1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:runtime_id": "rt_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:15.600Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:recording_started",
+      "object": {
+        "objectType": "bdm:Recording",
+        "id": "recording_mouse_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:recording_modality": "mouse",
+          "bdm:sample_rate": 30,
+          "bdm:recording_scope": "runtime"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:runtime_id": "rt_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:16.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_started",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_ks_1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:trial_index": "1",
+          "bdm:block_index": 0,
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:16.100Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Stimulus",
+        "id": "stimulus_ks_text_1",
+        "name": "Describe your experience"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:16.200Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:got_focus",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "textfield_response_1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:17.800Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:typed",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "textfield_response_1"
+      },
+      "result": {
+        "extensions": {
+          "bdm:typed_text": "Feeling well rested",
+          "bdm:key_sequence": ["F", "e", "e", "l", "i", "n", "g", " ", "w", "e", "l", "l"]
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:18.900Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:lost_focus",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "textfield_response_1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:19.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_ended",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_ks_1"
+      },
+      "result": {
+        "extensions": {
+          "bdm:response_id": "R_ks_1",
+          "bdm:response_description": "Feeling well rested",
+          "bdm:response_time": 2.900
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:19.100Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_started",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_ks_2"
+      },
+      "context": {
+        "extensions": {
+          "bdm:trial_index": "2",
+          "bdm:block_index": 0,
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:19.200Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Stimulus",
+        "id": "stimulus_ks_slider_1",
+        "name": "Rate your mood"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:19.300Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Panel",
+        "id": "panel_mood_matrix"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:21.500Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:adjusted",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "slider_mood_rating"
+      },
+      "result": {
+        "extensions": {
+          "bdm:current_value": 5
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:22.100Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:adjusted",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "slider_mood_rating"
+      },
+      "result": {
+        "extensions": {
+          "bdm:current_value": 7,
+          "bdm:previous_value": 5
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:23.000Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:drag_and_dropped",
+      "object": {
+        "objectType": "bdm:Option",
+        "id": "opt_category_high"
+      },
+      "result": {
+        "extensions": {
+          "bdm:drag_source": "panel_options_pool",
+          "bdm:drop_target": "panel_high_zone"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:23.800Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:deselected",
+      "object": {
+        "objectType": "bdm:Option",
+        "id": "opt_category_high"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:30.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:state_changed",
+      "object": {
+        "objectType": "bdm:Timer",
+        "id": "timer_trial_ks_2"
+      },
+      "result": {
+        "extensions": {
+          "bdm:state": "expired"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:30.010Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_ended",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_ks_2"
+      },
+      "result": {
+        "extensions": {
+          "bdm:response_id": "R_ks_2",
+          "bdm:response_time": 10.910,
+          "bdm:timed_out": true
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "2"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:35.000Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:lost_focus",
+      "object": {
+        "objectType": "bdm:Window",
+        "id": "window_main"
+      },
+      "result": {
+        "extensions": {
+          "bdm:focus_loss_reason": "tab_switch"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:00:35.050Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:paused",
+      "object": {
+        "objectType": "bdm:RuntimeInstance",
+        "id": "rt_ks_001"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:runtime_id": "rt_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:12.300Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:resumed",
+      "object": {
+        "objectType": "bdm:RuntimeInstance",
+        "id": "rt_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:pause_duration": 37.250
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:runtime_id": "rt_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:12.400Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:got_focus",
+      "object": {
+        "objectType": "bdm:Window",
+        "id": "window_main"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:12.500Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:recording_started",
+      "object": {
+        "objectType": "bdm:Recording",
+        "id": "recording_eeg_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:recording_modality": "eeg",
+          "bdm:sample_rate": 500,
+          "bdm:recording_scope": "block"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:block_index": 1
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:13.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_started",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_ks_3"
+      },
+      "context": {
+        "extensions": {
+          "bdm:trial_index": "3",
+          "bdm:block_index": 1,
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:13.100Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Stimulus",
+        "id": "stimulus_ks_nback_T",
+        "name": "letter_T"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "3"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:13.612Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_001"
+      },
+      "verb": "bdm:key_pressed",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "keyboard"
+      },
+      "result": {
+        "extensions": {
+          "bdm:key": "ArrowLeft",
+          "bdm:key_code": 37
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "3"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:14.100Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_ended",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_ks_3"
+      },
+      "result": {
+        "extensions": {
+          "bdm:response_id": "R_ks_3",
+          "bdm:response_description": "ArrowLeft",
+          "bdm:response_time": 0.512,
+          "bdm:correct": true
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:trial_index": "3"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:14.200Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:recording_ended",
+      "object": {
+        "objectType": "bdm:Recording",
+        "id": "recording_eeg_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:recording_url": "https://storage.behaverse.org/recordings/eeg_ks_001.edf",
+          "bdm:sha256": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+          "bdm:duration": 1.200
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:block_index": 1
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:14.300Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:state_changed",
+      "object": {
+        "objectType": "bdm:LocaleSwitch",
+        "id": "locale_switch_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:state": "changed",
+          "bdm:previous_locale": "en",
+          "bdm:current_locale": "fr"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:15.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:completed",
+      "object": {
+        "objectType": "bdm:RuntimeInstance",
+        "id": "rt_ks_001"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:runtime_id": "rt_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:15.200Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Feedback",
+        "id": "feedback_score_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:feedback_kind": "score"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:16.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:recording_ended",
+      "object": {
+        "objectType": "bdm:Recording",
+        "id": "recording_mouse_ks_001"
+      },
+      "result": {
+        "extensions": {
+          "bdm:recording_url": "https://storage.behaverse.org/recordings/mouse_ks_001.json",
+          "bdm:sha256": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+          "bdm:duration": 75.400
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:16.100Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:submitted",
+      "object": {
+        "objectType": "bdm:RuntimeInstance",
+        "id": "rt_ks_001"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_001",
+          "bdm:runtime_id": "rt_ks_001"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T15:01:17.000Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_ks_002"
+      },
+      "verb": "bdm:abandoned",
+      "object": {
+        "objectType": "bdm:RuntimeInstance",
+        "id": "rt_ks_002"
+      },
+      "result": {
+        "extensions": {
+          "bdm:abandon_reason": "participant_withdrew",
+          "bdm:abandon_at_trial": "5"
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_ks_002",
+          "bdm:runtime_id": "rt_ks_002"
+        }
+      }
+    }
+  ]
+}

--- a/event/examples/minimal_event.json
+++ b/event/examples/minimal_event.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-06-05T14:30:00Z",
+  "actor": {
+    "objectType": "bdm:Agent",
+    "id": "agent_001"
+  },
+  "verb": "bdm:initialized",
+  "object": {
+    "objectType": "bdm:RuntimeInstance",
+    "id": "rt_550e8400-e29b"
+  }
+}

--- a/event/examples/phq9_event_stream.json
+++ b/event/examples/phq9_event_stream.json
@@ -1,0 +1,182 @@
+{
+  "batch_id": "phq9_trial_1",
+  "events": [
+    {
+      "timestamp": "2026-06-05T14:30:00.000Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_started",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_phq9_item_1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:trial_index": "1",
+          "bdm:block_index": 0,
+          "bdm:session_id": "session_abc123",
+          "bdm:activity_index": 0,
+          "bdm:runtime_id": "rt_550e8400-e29b"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:00.120Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Screen",
+        "id": "screen_phq9_item_1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:runtime_id": "rt_550e8400-e29b"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:00.250Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Stimulus",
+        "id": "pr_phq9_1",
+        "name": "Little interest or pleasure in doing things"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:00.310Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:presented",
+      "object": {
+        "objectType": "bdm:Option",
+        "id": "opt_phq9_freq_group"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:02.840Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_001"
+      },
+      "verb": "bdm:clicked",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "radio_1"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:02.845Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_001"
+      },
+      "verb": "bdm:selected",
+      "object": {
+        "objectType": "bdm:Option",
+        "id": "opt_phq9_freq_4",
+        "name": "Nearly every day"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:03.210Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_001"
+      },
+      "verb": "bdm:clicked",
+      "object": {
+        "objectType": "bdm:UIComponent",
+        "id": "next_button"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:03.215Z",
+      "actor": {
+        "objectType": "bdm:Engine",
+        "id": "behaverse-web-viewer@v26.0603"
+      },
+      "verb": "bdm:trial_ended",
+      "object": {
+        "objectType": "bdm:Trial",
+        "id": "trial_phq9_item_1"
+      },
+      "result": {
+        "extensions": {
+          "bdm:response_id": "R_phq9_1",
+          "bdm:response_description": "Nearly every day",
+          "bdm:response_numeric": 3,
+          "bdm:response_option_index": 3,
+          "bdm:response_time": 3.215
+        }
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:trial_index": "1"
+        }
+      }
+    },
+    {
+      "timestamp": "2026-06-05T14:30:03.300Z",
+      "actor": {
+        "objectType": "bdm:Agent",
+        "id": "agent_001"
+      },
+      "verb": "bdm:navigated",
+      "object": {
+        "objectType": "bdm:Screen",
+        "id": "screen_phq9_item_2",
+        "name": "PHQ-9 Item 2"
+      },
+      "context": {
+        "extensions": {
+          "bdm:session_id": "session_abc123",
+          "bdm:runtime_id": "rt_550e8400-e29b"
+        }
+      }
+    }
+  ]
+}

--- a/event/field-definitions.json
+++ b/event/field-definitions.json
@@ -2,7 +2,7 @@
   "schema": "event",
   "version": "26.0608",
   "namespace": "https://behaverse.org/schemas/event",
-  "description": "Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style envelope (actor / verb / object) carrying a single canonical bdm: vocabulary, so one set of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG) are referenced via attachments, not inlined.",
+  "description": "Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style envelope (actor / verb / object) carrying a single canonical `bdm:` vocabulary, so one set of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG) are referenced via attachments, not inlined.",
   "fields": [
     {
       "name": "actor",
@@ -12,7 +12,7 @@
     },
     {
       "name": "verb",
-      "type": "string (bdm: CURIE)",
+      "type": "string",
       "requirement": "required",
       "description": "The action that occurred, drawn from the canonical verb vocabulary below."
     },

--- a/event/field-definitions.json
+++ b/event/field-definitions.json
@@ -1,0 +1,368 @@
+{
+  "schema": "event",
+  "version": "26.0608",
+  "namespace": "https://behaverse.org/schemas/event",
+  "description": "Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style envelope (actor / verb / object) carrying a single canonical bdm: vocabulary, so one set of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG) are referenced via attachments, not inlined.",
+  "fields": [
+    {
+      "name": "actor",
+      "type": "object",
+      "requirement": "required",
+      "description": "Who or what performed/experienced the event — `{objectType, id, name?}`, where objectType is one of the actor types below. (Renamed from `agent`; an Agent is one type of actor — BDM deviation D5.)"
+    },
+    {
+      "name": "verb",
+      "type": "string (bdm: CURIE)",
+      "requirement": "required",
+      "description": "The action that occurred, drawn from the canonical verb vocabulary below."
+    },
+    {
+      "name": "object",
+      "type": "object",
+      "requirement": "required",
+      "description": "What the action was performed on — `{objectType, id, name?}`, where objectType is one of the object types below."
+    },
+    {
+      "name": "timestamp",
+      "type": "datetime (RFC 9557)",
+      "requirement": "required",
+      "description": "When the event occurred, as an ISO 8601 / RFC 9557 datetime with timezone offset."
+    },
+    {
+      "name": "result",
+      "type": "object",
+      "requirement": "optional",
+      "description": "The outcome of the event (e.g. accuracy, response_time, score). Domain-specific payload lives under `result.extensions` keyed by `bdm:*` extension keys."
+    },
+    {
+      "name": "context",
+      "type": "object",
+      "requirement": "optional",
+      "description": "Contextual information (study, studyflow, and the session→activity→runtime→block→trial scoping hierarchy) under `context.extensions`, keyed by `bdm:*` extension keys."
+    },
+    {
+      "name": "version",
+      "type": "string",
+      "requirement": "optional",
+      "description": "The associated BDM/schema version (e.g. `v26.0608`). Typically populated by the LRS."
+    },
+    {
+      "name": "stored",
+      "type": "datetime (RFC 9557)",
+      "requirement": "optional",
+      "description": "When the event was stored in the LRS. Populated by the LRS."
+    },
+    {
+      "name": "updated",
+      "type": "datetime (RFC 9557)",
+      "requirement": "optional",
+      "description": "When the event was last updated in the LRS. Populated by the LRS."
+    },
+    {
+      "name": "authority",
+      "type": "object",
+      "requirement": "optional",
+      "description": "The authority that generated the event (e.g. the client app/developer). Populated by the LRS."
+    },
+    {
+      "name": "attachments",
+      "type": "array",
+      "requirement": "optional",
+      "description": "References to additional files/data associated with the event (stimulus blobs, recording files, timeseries), each with its own metadata. Payloads are not inlined."
+    }
+  ],
+  "vocabularies": {
+    "verbs": [
+      {
+        "name": "bdm:initialized",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance record minted; instrument loaded; engine ready. Nothing shown yet."
+      },
+      {
+        "name": "bdm:started",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "First content actually shown to the participant; starts the experiential clock."
+      },
+      {
+        "name": "bdm:paused",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance suspended (extended visibility loss, idle threshold, or explicit pause)."
+      },
+      {
+        "name": "bdm:resumed",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance continued after a pause. Carries bdm:pause_duration."
+      },
+      {
+        "name": "bdm:completed",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "All required content done. Distinct from submitted."
+      },
+      {
+        "name": "bdm:submitted",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "Data left the engine (POST to Orchestrator acknowledged)."
+      },
+      {
+        "name": "bdm:abandoned",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance ended without completion. Carries bdm:abandon_reason."
+      },
+      {
+        "name": "bdm:presented",
+        "object_types": [
+          "bdm:Screen",
+          "bdm:Panel",
+          "bdm:Stimulus",
+          "bdm:Option",
+          "bdm:Feedback",
+          "bdm:ConsentForm"
+        ],
+        "layer": "presentation",
+        "description": "Something became perceivable (rendered or played). Typically the response-time anchor for Stimulus/Option."
+      },
+      {
+        "name": "bdm:clicked",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "Pointer click (mouse, tap, stylus); the lowest-level click event."
+      },
+      {
+        "name": "bdm:drag_and_dropped",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "A drag-and-drop gesture completed. Carries bdm:drag_source and bdm:drop_target."
+      },
+      {
+        "name": "bdm:key_pressed",
+        "object_types": [
+          "bdm:UIComponent",
+          "bdm:Stimulus"
+        ],
+        "layer": "interaction",
+        "description": "A single key event. Carries bdm:key and bdm:key_code."
+      },
+      {
+        "name": "bdm:typed",
+        "object_types": [
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "A text input was committed (debounced). Carries bdm:typed_text and bdm:key_sequence."
+      },
+      {
+        "name": "bdm:selected",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "Discrete option selected (radio, checkbox, dropdown)."
+      },
+      {
+        "name": "bdm:deselected",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "Discrete option deselected (e.g. checkbox unchecked)."
+      },
+      {
+        "name": "bdm:adjusted",
+        "object_types": [
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "A continuous-value control was set (slider, spinner, dial). Carries bdm:current_value."
+      },
+      {
+        "name": "bdm:got_focus",
+        "object_types": [
+          "bdm:UIComponent",
+          "bdm:Window"
+        ],
+        "layer": "interaction",
+        "description": "Focus gained by an input control or by the runtime window/tab."
+      },
+      {
+        "name": "bdm:lost_focus",
+        "object_types": [
+          "bdm:UIComponent",
+          "bdm:Window"
+        ],
+        "layer": "interaction",
+        "description": "Focus lost. Window-level loss may (by threshold) lead to bdm:paused."
+      },
+      {
+        "name": "bdm:consented",
+        "object_types": [
+          "bdm:Consent"
+        ],
+        "layer": "interaction",
+        "description": "The agent committed to consent. Carries bdm:consent_text_hash and bdm:consent_scope."
+      },
+      {
+        "name": "bdm:trial_started",
+        "object_types": [
+          "bdm:Trial"
+        ],
+        "layer": "system",
+        "description": "A trial began. Carries bdm:trial_index and (when applicable) bdm:block_index / bdm:block_type."
+      },
+      {
+        "name": "bdm:trial_ended",
+        "object_types": [
+          "bdm:Trial"
+        ],
+        "layer": "system",
+        "description": "Trial finalised; a Response (trial) row is created. Carries the canonical response_*, response_time, correct/score, and bdm:response_id. Exactly one per trial."
+      },
+      {
+        "name": "bdm:state_changed",
+        "object_types": [
+          "bdm:Timer",
+          "bdm:Scorer",
+          "bdm:LocaleSwitch"
+        ],
+        "layer": "system",
+        "description": "A software-internal state change not tied to a presentation (timer, scorer, locale switch)."
+      },
+      {
+        "name": "bdm:recording_started",
+        "object_types": [
+          "bdm:Recording"
+        ],
+        "layer": "recording",
+        "description": "A continuous-data recording opened. Carries bdm:source and bdm:sample_rate."
+      },
+      {
+        "name": "bdm:recording_ended",
+        "object_types": [
+          "bdm:Recording"
+        ],
+        "layer": "recording",
+        "description": "A recording closed and was stored. Carries bdm:recording_url, bdm:recording_sha256, bdm:duration."
+      },
+      {
+        "name": "bdm:navigated",
+        "object_types": [
+          "bdm:Screen"
+        ],
+        "layer": "navigation",
+        "description": "Participant moved between Screens. Carries bdm:from_screen_id and bdm:to_screen_id."
+      }
+    ],
+    "object_types": [
+      {
+        "name": "bdm:RuntimeInstance",
+        "description": "One specific runtime execution of an Activity (distinguishes restarts)."
+      },
+      {
+        "name": "bdm:Screen",
+        "description": "One screen unit (questionnaire page, instructions screen, trial screen)."
+      },
+      {
+        "name": "bdm:Panel",
+        "description": "A within-screen layout grouping (e.g. matrix rows)."
+      },
+      {
+        "name": "bdm:Stimulus",
+        "description": "A displayed/audible thing the participant perceives within a trial."
+      },
+      {
+        "name": "bdm:Option",
+        "description": "A response option shown to the participant (radio, checkbox, dropdown entry)."
+      },
+      {
+        "name": "bdm:Trial",
+        "description": "The participant-administered unit; one Response (trial) row per Trial."
+      },
+      {
+        "name": "bdm:UIComponent",
+        "description": "An interactive UI control (radio, checkbox, slider, text field, button, key listener)."
+      },
+      {
+        "name": "bdm:Window",
+        "description": "The runtime window or browser tab (system-wide focus context)."
+      },
+      {
+        "name": "bdm:Feedback",
+        "description": "A post-response feedback display (correctness, score, band label, explanation)."
+      },
+      {
+        "name": "bdm:ConsentForm",
+        "description": "The consent form presented for review (what was shown)."
+      },
+      {
+        "name": "bdm:Consent",
+        "description": "The consent record — the audit entity capturing the agreement (what was committed to)."
+      },
+      {
+        "name": "bdm:Recording",
+        "description": "A continuous-data capture record (mouse, keyboard, EEG, …)."
+      },
+      {
+        "name": "bdm:Timer",
+        "description": "An internal software timer (trial timeout, idle detector)."
+      },
+      {
+        "name": "bdm:Scorer",
+        "description": "A Scorer entity invocation."
+      },
+      {
+        "name": "bdm:LocaleSwitch",
+        "description": "A programmatic locale change."
+      }
+    ],
+    "actor_types": [
+      {
+        "name": "bdm:Agent",
+        "description": "A specific agent — usually the human participant; may be an AI/automated participant."
+      },
+      {
+        "name": "bdm:Group",
+        "description": "A collection of agents acting together (xAPI compatibility; rare)."
+      },
+      {
+        "name": "bdm:Engine",
+        "description": "The runtime software acting on its own (web viewer, Godot viewer, game engine, CLI runner)."
+      },
+      {
+        "name": "bdm:Orchestrator",
+        "description": "The backend service that schedules Activities, mints RuntimeInstances, manages submission."
+      },
+      {
+        "name": "bdm:Researcher",
+        "description": "A researcher acting on the data (post-hoc annotation/correction)."
+      }
+    ]
+  }
+}

--- a/event/field-definitions.yaml
+++ b/event/field-definitions.yaml
@@ -1,0 +1,118 @@
+# Behaverse Event Schema - Field Definitions
+# Source of truth for the event envelope and the bdm: vocabulary. Edit this file, then run:
+#   uv run scripts/generate.py
+# Seeded from behaverse questionnaire_apps schemas/events (v26.0605) + design/05e_events_vocabulary.md.
+
+schema_metadata:
+  name: Behaverse Event Schema
+  version: '26.0608'
+  namespace: https://behaverse.org/schemas/event
+  description: >-
+    Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style
+    envelope (actor / verb / object) carrying a single canonical bdm: vocabulary, so one set
+    of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG)
+    are referenced via attachments, not inlined.
+
+# The event envelope — the shape of a single event object.
+fields:
+  - name: actor
+    type: object
+    requirement: required
+    description: Who or what performed/experienced the event — `{objectType, id, name?}`, where
+      objectType is one of the actor types below. (Renamed from `agent`; an Agent is one type of
+      actor — BDM deviation D5.)
+  - name: verb
+    type: 'string (bdm: CURIE)'
+    requirement: required
+    description: The action that occurred, drawn from the canonical verb vocabulary below.
+  - name: object
+    type: object
+    requirement: required
+    description: What the action was performed on — `{objectType, id, name?}`, where objectType is
+      one of the object types below.
+  - name: timestamp
+    type: datetime (RFC 9557)
+    requirement: required
+    description: When the event occurred, as an ISO 8601 / RFC 9557 datetime with timezone offset.
+  - name: result
+    type: object
+    requirement: optional
+    description: The outcome of the event (e.g. accuracy, response_time, score). Domain-specific
+      payload lives under `result.extensions` keyed by `bdm:*` extension keys.
+  - name: context
+    type: object
+    requirement: optional
+    description: Contextual information (study, studyflow, and the session→activity→runtime→block→trial
+      scoping hierarchy) under `context.extensions`, keyed by `bdm:*` extension keys.
+  - name: version
+    type: string
+    requirement: optional
+    description: The associated BDM/schema version (e.g. `v26.0608`). Typically populated by the LRS.
+  - name: stored
+    type: datetime (RFC 9557)
+    requirement: optional
+    description: When the event was stored in the LRS. Populated by the LRS.
+  - name: updated
+    type: datetime (RFC 9557)
+    requirement: optional
+    description: When the event was last updated in the LRS. Populated by the LRS.
+  - name: authority
+    type: object
+    requirement: optional
+    description: The authority that generated the event (e.g. the client app/developer). Populated
+      by the LRS.
+  - name: attachments
+    type: array
+    requirement: optional
+    description: References to additional files/data associated with the event (stimulus blobs,
+      recording files, timeseries), each with its own metadata. Payloads are not inlined.
+
+# The canonical bdm: vocabulary (BDM deviation D4).
+vocabularies:
+  verbs:
+    - {name: 'bdm:initialized', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance record minted; instrument loaded; engine ready. Nothing shown yet.'}
+    - {name: 'bdm:started', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'First content actually shown to the participant; starts the experiential clock.'}
+    - {name: 'bdm:paused', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance suspended (extended visibility loss, idle threshold, or explicit pause).'}
+    - {name: 'bdm:resumed', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance continued after a pause. Carries bdm:pause_duration.'}
+    - {name: 'bdm:completed', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'All required content done. Distinct from submitted.'}
+    - {name: 'bdm:submitted', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'Data left the engine (POST to Orchestrator acknowledged).'}
+    - {name: 'bdm:abandoned', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance ended without completion. Carries bdm:abandon_reason.'}
+    - {name: 'bdm:presented', object_types: ['bdm:Screen', 'bdm:Panel', 'bdm:Stimulus', 'bdm:Option', 'bdm:Feedback', 'bdm:ConsentForm'], layer: presentation, description: 'Something became perceivable (rendered or played). Typically the response-time anchor for Stimulus/Option.'}
+    - {name: 'bdm:clicked', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'Pointer click (mouse, tap, stylus); the lowest-level click event.'}
+    - {name: 'bdm:drag_and_dropped', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'A drag-and-drop gesture completed. Carries bdm:drag_source and bdm:drop_target.'}
+    - {name: 'bdm:key_pressed', object_types: ['bdm:UIComponent', 'bdm:Stimulus'], layer: interaction, description: 'A single key event. Carries bdm:key and bdm:key_code.'}
+    - {name: 'bdm:typed', object_types: ['bdm:UIComponent'], layer: interaction, description: 'A text input was committed (debounced). Carries bdm:typed_text and bdm:key_sequence.'}
+    - {name: 'bdm:selected', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'Discrete option selected (radio, checkbox, dropdown).'}
+    - {name: 'bdm:deselected', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'Discrete option deselected (e.g. checkbox unchecked).'}
+    - {name: 'bdm:adjusted', object_types: ['bdm:UIComponent'], layer: interaction, description: 'A continuous-value control was set (slider, spinner, dial). Carries bdm:current_value.'}
+    - {name: 'bdm:got_focus', object_types: ['bdm:UIComponent', 'bdm:Window'], layer: interaction, description: 'Focus gained by an input control or by the runtime window/tab.'}
+    - {name: 'bdm:lost_focus', object_types: ['bdm:UIComponent', 'bdm:Window'], layer: interaction, description: 'Focus lost. Window-level loss may (by threshold) lead to bdm:paused.'}
+    - {name: 'bdm:consented', object_types: ['bdm:Consent'], layer: interaction, description: 'The agent committed to consent. Carries bdm:consent_text_hash and bdm:consent_scope.'}
+    - {name: 'bdm:trial_started', object_types: ['bdm:Trial'], layer: system, description: 'A trial began. Carries bdm:trial_index and (when applicable) bdm:block_index / bdm:block_type.'}
+    - {name: 'bdm:trial_ended', object_types: ['bdm:Trial'], layer: system, description: 'Trial finalised; a Response (trial) row is created. Carries the canonical response_*, response_time, correct/score, and bdm:response_id. Exactly one per trial.'}
+    - {name: 'bdm:state_changed', object_types: ['bdm:Timer', 'bdm:Scorer', 'bdm:LocaleSwitch'], layer: system, description: 'A software-internal state change not tied to a presentation (timer, scorer, locale switch).'}
+    - {name: 'bdm:recording_started', object_types: ['bdm:Recording'], layer: recording, description: 'A continuous-data recording opened. Carries bdm:source and bdm:sample_rate.'}
+    - {name: 'bdm:recording_ended', object_types: ['bdm:Recording'], layer: recording, description: 'A recording closed and was stored. Carries bdm:recording_url, bdm:recording_sha256, bdm:duration.'}
+    - {name: 'bdm:navigated', object_types: ['bdm:Screen'], layer: navigation, description: 'Participant moved between Screens. Carries bdm:from_screen_id and bdm:to_screen_id.'}
+  object_types:
+    - {name: 'bdm:RuntimeInstance', description: 'One specific runtime execution of an Activity (distinguishes restarts).'}
+    - {name: 'bdm:Screen', description: 'One screen unit (questionnaire page, instructions screen, trial screen).'}
+    - {name: 'bdm:Panel', description: 'A within-screen layout grouping (e.g. matrix rows).'}
+    - {name: 'bdm:Stimulus', description: 'A displayed/audible thing the participant perceives within a trial.'}
+    - {name: 'bdm:Option', description: 'A response option shown to the participant (radio, checkbox, dropdown entry).'}
+    - {name: 'bdm:Trial', description: 'The participant-administered unit; one Response (trial) row per Trial.'}
+    - {name: 'bdm:UIComponent', description: 'An interactive UI control (radio, checkbox, slider, text field, button, key listener).'}
+    - {name: 'bdm:Window', description: 'The runtime window or browser tab (system-wide focus context).'}
+    - {name: 'bdm:Feedback', description: 'A post-response feedback display (correctness, score, band label, explanation).'}
+    - {name: 'bdm:ConsentForm', description: 'The consent form presented for review (what was shown).'}
+    - {name: 'bdm:Consent', description: 'The consent record — the audit entity capturing the agreement (what was committed to).'}
+    - {name: 'bdm:Recording', description: 'A continuous-data capture record (mouse, keyboard, EEG, …).'}
+    - {name: 'bdm:Timer', description: 'An internal software timer (trial timeout, idle detector).'}
+    - {name: 'bdm:Scorer', description: 'A Scorer entity invocation.'}
+    - {name: 'bdm:LocaleSwitch', description: 'A programmatic locale change.'}
+  actor_types:
+    - {name: 'bdm:Agent', description: 'A specific agent — usually the human participant; may be an AI/automated participant.'}
+    - {name: 'bdm:Group', description: 'A collection of agents acting together (xAPI compatibility; rare).'}
+    - {name: 'bdm:Engine', description: 'The runtime software acting on its own (web viewer, Godot viewer, game engine, CLI runner).'}
+    - {name: 'bdm:Orchestrator', description: 'The backend service that schedules Activities, mints RuntimeInstances, manages submission.'}
+    - {name: 'bdm:Researcher', description: 'A researcher acting on the data (post-hoc annotation/correction).'}

--- a/event/field-definitions.yaml
+++ b/event/field-definitions.yaml
@@ -7,29 +7,22 @@ schema_metadata:
   name: Behaverse Event Schema
   version: '26.0608'
   namespace: https://behaverse.org/schemas/event
-  description: >-
-    Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style
-    envelope (actor / verb / object) carrying a single canonical bdm: vocabulary, so one set
-    of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG)
-    are referenced via attachments, not inlined.
+  description: Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style envelope (actor / verb / object) carrying a single canonical `bdm:` vocabulary, so one set of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG) are referenced via attachments, not inlined.
 
 # The event envelope — the shape of a single event object.
 fields:
   - name: actor
     type: object
     requirement: required
-    description: Who or what performed/experienced the event — `{objectType, id, name?}`, where
-      objectType is one of the actor types below. (Renamed from `agent`; an Agent is one type of
-      actor — BDM deviation D5.)
+    description: 'Who or what performed/experienced the event — `{objectType, id, name?}`, where objectType is one of the actor types below. (Renamed from `agent`; an Agent is one type of actor — BDM deviation D5.)'
   - name: verb
-    type: 'string (bdm: CURIE)'
+    type: string
     requirement: required
     description: The action that occurred, drawn from the canonical verb vocabulary below.
   - name: object
     type: object
     requirement: required
-    description: What the action was performed on — `{objectType, id, name?}`, where objectType is
-      one of the object types below.
+    description: 'What the action was performed on — `{objectType, id, name?}`, where objectType is one of the object types below.'
   - name: timestamp
     type: datetime (RFC 9557)
     requirement: required
@@ -37,13 +30,11 @@ fields:
   - name: result
     type: object
     requirement: optional
-    description: The outcome of the event (e.g. accuracy, response_time, score). Domain-specific
-      payload lives under `result.extensions` keyed by `bdm:*` extension keys.
+    description: The outcome of the event (e.g. accuracy, response_time, score). Domain-specific payload lives under `result.extensions` keyed by `bdm:*` extension keys.
   - name: context
     type: object
     requirement: optional
-    description: Contextual information (study, studyflow, and the session→activity→runtime→block→trial
-      scoping hierarchy) under `context.extensions`, keyed by `bdm:*` extension keys.
+    description: Contextual information (study, studyflow, and the session→activity→runtime→block→trial scoping hierarchy) under `context.extensions`, keyed by `bdm:*` extension keys.
   - name: version
     type: string
     requirement: optional
@@ -59,60 +50,150 @@ fields:
   - name: authority
     type: object
     requirement: optional
-    description: The authority that generated the event (e.g. the client app/developer). Populated
-      by the LRS.
+    description: The authority that generated the event (e.g. the client app/developer). Populated by the LRS.
   - name: attachments
     type: array
     requirement: optional
-    description: References to additional files/data associated with the event (stimulus blobs,
-      recording files, timeseries), each with its own metadata. Payloads are not inlined.
+    description: References to additional files/data associated with the event (stimulus blobs, recording files, timeseries), each with its own metadata. Payloads are not inlined.
 
 # The canonical bdm: vocabulary (BDM deviation D4).
 vocabularies:
   verbs:
-    - {name: 'bdm:initialized', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance record minted; instrument loaded; engine ready. Nothing shown yet.'}
-    - {name: 'bdm:started', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'First content actually shown to the participant; starts the experiential clock.'}
-    - {name: 'bdm:paused', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance suspended (extended visibility loss, idle threshold, or explicit pause).'}
-    - {name: 'bdm:resumed', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance continued after a pause. Carries bdm:pause_duration.'}
-    - {name: 'bdm:completed', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'All required content done. Distinct from submitted.'}
-    - {name: 'bdm:submitted', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'Data left the engine (POST to Orchestrator acknowledged).'}
-    - {name: 'bdm:abandoned', object_types: ['bdm:RuntimeInstance'], layer: lifecycle, description: 'RuntimeInstance ended without completion. Carries bdm:abandon_reason.'}
-    - {name: 'bdm:presented', object_types: ['bdm:Screen', 'bdm:Panel', 'bdm:Stimulus', 'bdm:Option', 'bdm:Feedback', 'bdm:ConsentForm'], layer: presentation, description: 'Something became perceivable (rendered or played). Typically the response-time anchor for Stimulus/Option.'}
-    - {name: 'bdm:clicked', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'Pointer click (mouse, tap, stylus); the lowest-level click event.'}
-    - {name: 'bdm:drag_and_dropped', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'A drag-and-drop gesture completed. Carries bdm:drag_source and bdm:drop_target.'}
-    - {name: 'bdm:key_pressed', object_types: ['bdm:UIComponent', 'bdm:Stimulus'], layer: interaction, description: 'A single key event. Carries bdm:key and bdm:key_code.'}
-    - {name: 'bdm:typed', object_types: ['bdm:UIComponent'], layer: interaction, description: 'A text input was committed (debounced). Carries bdm:typed_text and bdm:key_sequence.'}
-    - {name: 'bdm:selected', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'Discrete option selected (radio, checkbox, dropdown).'}
-    - {name: 'bdm:deselected', object_types: ['bdm:Option', 'bdm:UIComponent'], layer: interaction, description: 'Discrete option deselected (e.g. checkbox unchecked).'}
-    - {name: 'bdm:adjusted', object_types: ['bdm:UIComponent'], layer: interaction, description: 'A continuous-value control was set (slider, spinner, dial). Carries bdm:current_value.'}
-    - {name: 'bdm:got_focus', object_types: ['bdm:UIComponent', 'bdm:Window'], layer: interaction, description: 'Focus gained by an input control or by the runtime window/tab.'}
-    - {name: 'bdm:lost_focus', object_types: ['bdm:UIComponent', 'bdm:Window'], layer: interaction, description: 'Focus lost. Window-level loss may (by threshold) lead to bdm:paused.'}
-    - {name: 'bdm:consented', object_types: ['bdm:Consent'], layer: interaction, description: 'The agent committed to consent. Carries bdm:consent_text_hash and bdm:consent_scope.'}
-    - {name: 'bdm:trial_started', object_types: ['bdm:Trial'], layer: system, description: 'A trial began. Carries bdm:trial_index and (when applicable) bdm:block_index / bdm:block_type.'}
-    - {name: 'bdm:trial_ended', object_types: ['bdm:Trial'], layer: system, description: 'Trial finalised; a Response (trial) row is created. Carries the canonical response_*, response_time, correct/score, and bdm:response_id. Exactly one per trial.'}
-    - {name: 'bdm:state_changed', object_types: ['bdm:Timer', 'bdm:Scorer', 'bdm:LocaleSwitch'], layer: system, description: 'A software-internal state change not tied to a presentation (timer, scorer, locale switch).'}
-    - {name: 'bdm:recording_started', object_types: ['bdm:Recording'], layer: recording, description: 'A continuous-data recording opened. Carries bdm:source and bdm:sample_rate.'}
-    - {name: 'bdm:recording_ended', object_types: ['bdm:Recording'], layer: recording, description: 'A recording closed and was stored. Carries bdm:recording_url, bdm:recording_sha256, bdm:duration.'}
-    - {name: 'bdm:navigated', object_types: ['bdm:Screen'], layer: navigation, description: 'Participant moved between Screens. Carries bdm:from_screen_id and bdm:to_screen_id.'}
+    - name: 'bdm:initialized'
+      object_types: ['bdm:RuntimeInstance']
+      layer: lifecycle
+      description: RuntimeInstance record minted; instrument loaded; engine ready. Nothing shown yet.
+    - name: 'bdm:started'
+      object_types: ['bdm:RuntimeInstance']
+      layer: lifecycle
+      description: First content actually shown to the participant; starts the experiential clock.
+    - name: 'bdm:paused'
+      object_types: ['bdm:RuntimeInstance']
+      layer: lifecycle
+      description: RuntimeInstance suspended (extended visibility loss, idle threshold, or explicit pause).
+    - name: 'bdm:resumed'
+      object_types: ['bdm:RuntimeInstance']
+      layer: lifecycle
+      description: RuntimeInstance continued after a pause. Carries bdm:pause_duration.
+    - name: 'bdm:completed'
+      object_types: ['bdm:RuntimeInstance']
+      layer: lifecycle
+      description: All required content done. Distinct from submitted.
+    - name: 'bdm:submitted'
+      object_types: ['bdm:RuntimeInstance']
+      layer: lifecycle
+      description: Data left the engine (POST to Orchestrator acknowledged).
+    - name: 'bdm:abandoned'
+      object_types: ['bdm:RuntimeInstance']
+      layer: lifecycle
+      description: RuntimeInstance ended without completion. Carries bdm:abandon_reason.
+    - name: 'bdm:presented'
+      object_types: ['bdm:Screen', 'bdm:Panel', 'bdm:Stimulus', 'bdm:Option', 'bdm:Feedback', 'bdm:ConsentForm']
+      layer: presentation
+      description: Something became perceivable (rendered or played). Typically the response-time anchor for Stimulus/Option.
+    - name: 'bdm:clicked'
+      object_types: ['bdm:Option', 'bdm:UIComponent']
+      layer: interaction
+      description: Pointer click (mouse, tap, stylus); the lowest-level click event.
+    - name: 'bdm:drag_and_dropped'
+      object_types: ['bdm:Option', 'bdm:UIComponent']
+      layer: interaction
+      description: A drag-and-drop gesture completed. Carries bdm:drag_source and bdm:drop_target.
+    - name: 'bdm:key_pressed'
+      object_types: ['bdm:UIComponent', 'bdm:Stimulus']
+      layer: interaction
+      description: A single key event. Carries bdm:key and bdm:key_code.
+    - name: 'bdm:typed'
+      object_types: ['bdm:UIComponent']
+      layer: interaction
+      description: A text input was committed (debounced). Carries bdm:typed_text and bdm:key_sequence.
+    - name: 'bdm:selected'
+      object_types: ['bdm:Option', 'bdm:UIComponent']
+      layer: interaction
+      description: Discrete option selected (radio, checkbox, dropdown).
+    - name: 'bdm:deselected'
+      object_types: ['bdm:Option', 'bdm:UIComponent']
+      layer: interaction
+      description: Discrete option deselected (e.g. checkbox unchecked).
+    - name: 'bdm:adjusted'
+      object_types: ['bdm:UIComponent']
+      layer: interaction
+      description: A continuous-value control was set (slider, spinner, dial). Carries bdm:current_value.
+    - name: 'bdm:got_focus'
+      object_types: ['bdm:UIComponent', 'bdm:Window']
+      layer: interaction
+      description: Focus gained by an input control or by the runtime window/tab.
+    - name: 'bdm:lost_focus'
+      object_types: ['bdm:UIComponent', 'bdm:Window']
+      layer: interaction
+      description: Focus lost. Window-level loss may (by threshold) lead to bdm:paused.
+    - name: 'bdm:consented'
+      object_types: ['bdm:Consent']
+      layer: interaction
+      description: The agent committed to consent. Carries bdm:consent_text_hash and bdm:consent_scope.
+    - name: 'bdm:trial_started'
+      object_types: ['bdm:Trial']
+      layer: system
+      description: A trial began. Carries bdm:trial_index and (when applicable) bdm:block_index / bdm:block_type.
+    - name: 'bdm:trial_ended'
+      object_types: ['bdm:Trial']
+      layer: system
+      description: Trial finalised; a Response (trial) row is created. Carries the canonical response_*, response_time, correct/score, and bdm:response_id. Exactly one per trial.
+    - name: 'bdm:state_changed'
+      object_types: ['bdm:Timer', 'bdm:Scorer', 'bdm:LocaleSwitch']
+      layer: system
+      description: A software-internal state change not tied to a presentation (timer, scorer, locale switch).
+    - name: 'bdm:recording_started'
+      object_types: ['bdm:Recording']
+      layer: recording
+      description: A continuous-data recording opened. Carries bdm:source and bdm:sample_rate.
+    - name: 'bdm:recording_ended'
+      object_types: ['bdm:Recording']
+      layer: recording
+      description: A recording closed and was stored. Carries bdm:recording_url, bdm:recording_sha256, bdm:duration.
+    - name: 'bdm:navigated'
+      object_types: ['bdm:Screen']
+      layer: navigation
+      description: Participant moved between Screens. Carries bdm:from_screen_id and bdm:to_screen_id.
   object_types:
-    - {name: 'bdm:RuntimeInstance', description: 'One specific runtime execution of an Activity (distinguishes restarts).'}
-    - {name: 'bdm:Screen', description: 'One screen unit (questionnaire page, instructions screen, trial screen).'}
-    - {name: 'bdm:Panel', description: 'A within-screen layout grouping (e.g. matrix rows).'}
-    - {name: 'bdm:Stimulus', description: 'A displayed/audible thing the participant perceives within a trial.'}
-    - {name: 'bdm:Option', description: 'A response option shown to the participant (radio, checkbox, dropdown entry).'}
-    - {name: 'bdm:Trial', description: 'The participant-administered unit; one Response (trial) row per Trial.'}
-    - {name: 'bdm:UIComponent', description: 'An interactive UI control (radio, checkbox, slider, text field, button, key listener).'}
-    - {name: 'bdm:Window', description: 'The runtime window or browser tab (system-wide focus context).'}
-    - {name: 'bdm:Feedback', description: 'A post-response feedback display (correctness, score, band label, explanation).'}
-    - {name: 'bdm:ConsentForm', description: 'The consent form presented for review (what was shown).'}
-    - {name: 'bdm:Consent', description: 'The consent record — the audit entity capturing the agreement (what was committed to).'}
-    - {name: 'bdm:Recording', description: 'A continuous-data capture record (mouse, keyboard, EEG, …).'}
-    - {name: 'bdm:Timer', description: 'An internal software timer (trial timeout, idle detector).'}
-    - {name: 'bdm:Scorer', description: 'A Scorer entity invocation.'}
-    - {name: 'bdm:LocaleSwitch', description: 'A programmatic locale change.'}
+    - name: 'bdm:RuntimeInstance'
+      description: One specific runtime execution of an Activity (distinguishes restarts).
+    - name: 'bdm:Screen'
+      description: One screen unit (questionnaire page, instructions screen, trial screen).
+    - name: 'bdm:Panel'
+      description: A within-screen layout grouping (e.g. matrix rows).
+    - name: 'bdm:Stimulus'
+      description: A displayed/audible thing the participant perceives within a trial.
+    - name: 'bdm:Option'
+      description: A response option shown to the participant (radio, checkbox, dropdown entry).
+    - name: 'bdm:Trial'
+      description: The participant-administered unit; one Response (trial) row per Trial.
+    - name: 'bdm:UIComponent'
+      description: An interactive UI control (radio, checkbox, slider, text field, button, key listener).
+    - name: 'bdm:Window'
+      description: The runtime window or browser tab (system-wide focus context).
+    - name: 'bdm:Feedback'
+      description: A post-response feedback display (correctness, score, band label, explanation).
+    - name: 'bdm:ConsentForm'
+      description: The consent form presented for review (what was shown).
+    - name: 'bdm:Consent'
+      description: The consent record — the audit entity capturing the agreement (what was committed to).
+    - name: 'bdm:Recording'
+      description: A continuous-data capture record (mouse, keyboard, EEG, …).
+    - name: 'bdm:Timer'
+      description: An internal software timer (trial timeout, idle detector).
+    - name: 'bdm:Scorer'
+      description: A Scorer entity invocation.
+    - name: 'bdm:LocaleSwitch'
+      description: A programmatic locale change.
   actor_types:
-    - {name: 'bdm:Agent', description: 'A specific agent — usually the human participant; may be an AI/automated participant.'}
-    - {name: 'bdm:Group', description: 'A collection of agents acting together (xAPI compatibility; rare).'}
-    - {name: 'bdm:Engine', description: 'The runtime software acting on its own (web viewer, Godot viewer, game engine, CLI runner).'}
-    - {name: 'bdm:Orchestrator', description: 'The backend service that schedules Activities, mints RuntimeInstances, manages submission.'}
-    - {name: 'bdm:Researcher', description: 'A researcher acting on the data (post-hoc annotation/correction).'}
+    - name: 'bdm:Agent'
+      description: A specific agent — usually the human participant; may be an AI/automated participant.
+    - name: 'bdm:Group'
+      description: A collection of agents acting together (xAPI compatibility; rare).
+    - name: 'bdm:Engine'
+      description: The runtime software acting on its own (web viewer, Godot viewer, game engine, CLI runner).
+    - name: 'bdm:Orchestrator'
+      description: The backend service that schedules Activities, mints RuntimeInstances, manages submission.
+    - name: 'bdm:Researcher'
+      description: A researcher acting on the data (post-hoc annotation/correction).

--- a/event/schema.json
+++ b/event/schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://behaverse.org/schemas/event/v26.0608/schema.json",
+  "title": "Behaverse Event Data (BDM Events extension)",
+  "description": "Per OD-19 (resolved 2026-06-05), BDM Events vocabulary covering questionnaires, cognitive tasks, and video games under a single bdm: namespace.",
+  "oneOf": [
+    { "$ref": "#/$defs/Event" },
+    { "$ref": "#/$defs/EventBatch" }
+  ],
+  "$defs": {
+    "Event": {
+      "type": "object",
+      "required": ["actor", "verb", "object", "timestamp"],
+      "properties": {
+        "version":    { "type": "string", "pattern": "^v\\d{2}\\.\\d{4}$" },
+        "timestamp":  { "type": "string", "format": "date-time" },
+        "stored":     { "type": "string", "format": "date-time" },
+        "updated":    { "type": "string", "format": "date-time" },
+        "actor":      { "$ref": "#/$defs/Actor" },
+        "verb":       { "$ref": "#/$defs/Verb" },
+        "object":     { "$ref": "#/$defs/EventObject" },
+        "result":     { "$ref": "#/$defs/Result" },
+        "context":    { "$ref": "#/$defs/Context" },
+        "authority":  { "type": "object" },
+        "attachments":{ "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false,
+      "patternProperties": { "^x_": {} }
+    },
+    "EventBatch": {
+      "type": "object",
+      "required": ["events"],
+      "properties": {
+        "batch_id": { "type": "string" },
+        "events":   { "type": "array", "items": { "$ref": "#/$defs/Event" }, "minItems": 1 }
+      },
+      "additionalProperties": false,
+      "patternProperties": { "^x_": {} }
+    },
+    "Actor": {
+      "type": "object",
+      "required": ["objectType", "id"],
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "enum": ["bdm:Agent", "bdm:Group", "bdm:Engine", "bdm:Orchestrator", "bdm:Researcher"]
+        },
+        "id":   { "type": "string" },
+        "name": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "Verb": {
+      "type": "string",
+      "enum": [
+        "bdm:initialized", "bdm:started", "bdm:paused", "bdm:resumed",
+        "bdm:completed", "bdm:submitted", "bdm:abandoned",
+        "bdm:presented",
+        "bdm:clicked", "bdm:drag_and_dropped", "bdm:key_pressed", "bdm:typed",
+        "bdm:selected", "bdm:deselected", "bdm:adjusted",
+        "bdm:got_focus", "bdm:lost_focus", "bdm:consented",
+        "bdm:trial_started", "bdm:trial_ended", "bdm:state_changed",
+        "bdm:recording_started", "bdm:recording_ended",
+        "bdm:navigated"
+      ]
+    },
+    "EventObject": {
+      "type": "object",
+      "required": ["objectType", "id"],
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "enum": [
+            "bdm:RuntimeInstance", "bdm:Screen", "bdm:Panel", "bdm:Stimulus",
+            "bdm:Option", "bdm:Trial", "bdm:UIComponent", "bdm:Window",
+            "bdm:Feedback", "bdm:ConsentForm", "bdm:Consent",
+            "bdm:Recording", "bdm:Timer", "bdm:Scorer", "bdm:LocaleSwitch"
+          ]
+        },
+        "id":   { "type": "string" },
+        "name": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "Result": {
+      "type": "object",
+      "properties": {
+        "extensions": { "$ref": "#/$defs/BDMExtensions" }
+      },
+      "additionalProperties": true
+    },
+    "Context": {
+      "type": "object",
+      "properties": {
+        "extensions": { "$ref": "#/$defs/BDMExtensions" }
+      },
+      "additionalProperties": true
+    },
+    "BDMExtensions": {
+      "type": "object",
+      "patternProperties": {
+        "^bdm:[a-z][a-z0-9_]*$": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/event/scripts/generate.py
+++ b/event/scripts/generate.py
@@ -1,0 +1,63 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyyaml"]
+# ///
+"""Generate field-definitions.json for the event schema from field-definitions.yaml.
+
+The event schema is a single object (the event envelope) plus the canonical bdm: vocabulary.
+This emits field-definitions.json — the render artifact consumed by behaverse/data-model and
+the docs site. The validation contract (schema.json) and context.jsonld are maintained
+alongside (relocated from the questionnaire_apps events schema).
+
+Usage:
+    uv run scripts/generate.py
+    uv run scripts/generate.py --check
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml  # type: ignore
+
+EVENT_DIR = Path(__file__).parent.parent
+
+
+def build_field_definitions(src: dict) -> dict:
+    meta = src["schema_metadata"]
+    out = {
+        "schema": "event",
+        "version": meta["version"],
+        "namespace": meta["namespace"],
+        "description": meta["description"],
+        "fields": src["fields"],
+    }
+    if "vocabularies" in src:
+        out["vocabularies"] = src["vocabularies"]
+    return out
+
+
+def main() -> None:
+    check = "--check" in sys.argv
+    src = yaml.safe_load((EVENT_DIR / "field-definitions.yaml").read_text())
+    rendered = json.dumps(build_field_definitions(src), indent=2, ensure_ascii=False) + "\n"
+
+    target = EVENT_DIR / "field-definitions.json"
+    if check:
+        if (target.read_text() if target.exists() else "") != rendered:
+            print(f"stale: {target} would change — run without --check")
+            sys.exit(1)
+        print(f"up to date: {target}")
+        return
+
+    target.write_text(rendered)
+    src_yaml = yaml.safe_load((EVENT_DIR / "field-definitions.yaml").read_text())
+    v = src_yaml.get("vocabularies", {})
+    print(f"✓ generated {target} — {len(src['fields'])} envelope fields, "
+          f"{len(v.get('verbs', []))} verbs, {len(v.get('object_types', []))} object types, "
+          f"{len(v.get('actor_types', []))} actor types")
+
+
+if __name__ == "__main__":
+    main()

--- a/trial/CHANGELOG.md
+++ b/trial/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog — Behaverse Trial Schema
+
+All notable changes to the trial schema are documented here. CalVer `vYY.MMDD`.
+
+## [26.0608] - 2026-06-08
+
+### Added
+
+- Initial relocation of the trial tables from `behaverse/data-model` into `behaverse/schemas`.
+- `field-definitions.yaml` (source of truth) and generated `field-definitions.json` for the 7 published tables — Response, Stimulus, Option, Input, StimulusComponent, OptionComponent, Instrument (161 fields total).
+- `scripts/generate.py` to regenerate `field-definitions.json` from the source.
+
+### Changed
+
+- Re-keyed fields to the schemas-repo convention: `variable_name` → `name`, `data_type` → `type`, `required` (bool) → `requirement` (`required` / `optional`).
+- Stripped Quarto/Bootstrap markup from descriptions and notes (table references such as the `Stimulus` table are now plain backticked names); dropped `.tip` / `.important` / `.warning` callout-level markers (text retained).
+
+### Notes
+
+- Published as-is; known data issues (D1 `stimulus_id` typing, D3 `session_id`/`session_index`, D5 `agent` → `actor`) are tracked as follow-ups, not applied in this relocation.
+- `schema.json` (validation) and `context.jsonld` are not yet generated.

--- a/trial/README.md
+++ b/trial/README.md
@@ -1,0 +1,50 @@
+# Behaverse Trial Schema (WIP)
+
+**Version:** v26.0608
+**Namespace:** `https://behaverse.org/schemas/trial#`
+**Source of truth:** [`field-definitions.yaml`](field-definitions.yaml) — edit it, then run `uv run scripts/generate.py`
+
+## Overview
+
+The Behaverse Trial Schema defines a set of tidy tables describing **trial-level** behavioral data — the task-specific aggregates derived from raw events — for cognitive tests and questionnaires. It is the *Trials* layer of the Behaverse Data Model (BDM); see **[behaverse.org/data-model](https://behaverse.org/data-model)** for the human-facing guides, conventions, and explanations.
+
+A trial is a single instance of a participant interacting with a task. Trial information is spread across several related tables, joined by `_id` foreign keys.
+
+## Tables
+
+| Table | Fields | Description |
+|-------|-------:|-------------|
+| **Response** | 75 | Main table; one row per response in a trial. |
+| **Stimulus** | 19 | Each stimulus shown during a trial. |
+| **Option** | 18 | Each option a subject could choose from. |
+| **Input** | 15 | Detailed log of inputs/clicks during the trial. |
+| **StimulusComponent** | 13 | Components that make up a stimulus. |
+| **OptionComponent** | 14 | Components that make up an option. |
+| **Instrument** | 7 | The instrument (and its parameterizations) used for acquisition. |
+
+## Conventions
+
+- A trailing `_id` denotes a **foreign key** into the table of that name (e.g. `stimulus_id` → the Stimulus table).
+- When several entities occur in one trial (e.g. multiple stimuli), their ids/values are concatenated into a single string on CSV export.
+
+## Artifacts
+
+| File | Status | Purpose |
+|------|--------|---------|
+| [`field-definitions.yaml`](field-definitions.yaml) | ✅ | Source of truth (hand-maintained). |
+| [`field-definitions.json`](field-definitions.json) | ✅ generated | Render contract consumed by `behaverse/data-model` and the docs site. |
+| `schema.json` | ⏳ planned | JSON Schema for validation (per table). |
+| `context.jsonld` | ⏳ planned | JSON-LD context. |
+
+## Status & follow-ups
+
+Relocated from `behaverse/data-model` (where it was generated from a Google Sheet). Published **as-is**; these known issues are tracked as follow-ups, not yet applied:
+
+- **D1** — `Response.stimulus_id` typing (`integer` → `string | integer`) for compositional questionnaire stimuli.
+- **D3** — `Response.session_id` is typed integer but its description calls it `session_index`; rename and add a UUID `session_id`.
+- **D5** — events `agent` → `actor` (in the forthcoming `event` schema).
+- Several `description`/`range` fields still mix prose with enum listings that could become structured `enum` constraints.
+
+## Versioning
+
+CalVer `vYY.MMDD`. See the repo-wide [`VERSIONING.md`](../VERSIONING.md).

--- a/trial/field-definitions.json
+++ b/trial/field-definitions.json
@@ -1,0 +1,1734 @@
+{
+  "schema": "trial",
+  "version": "26.0608",
+  "namespace": "https://behaverse.org/schemas/trial",
+  "description": "Tidy tables describing trial-level behavioral data for cognitive tests and questionnaires, derived from raw events.",
+  "tables": [
+    {
+      "name": "Response",
+      "label": "Response",
+      "description": "Main table where each row describes a response in a trial.",
+      "notes": [
+        "The information in this table should be sufficient for most analyses, but more detailed information may be linked from other tables via identifiers (`response_id` and `trial_index`)."
+      ],
+      "fields": [
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "response_id",
+          "type": "PRIMARY KEY",
+          "requirement": "required",
+          "description": "A unique identifier assigned to responses in temporal order, meaning that larger IDs correspond to more recent responses that occurred later in time. This ID is unique within this table; no two rows share the same value.",
+          "notes": [
+            "This identifier is used by other tables, for example `Stimulus` table which describes in greater detail the sequence of images shown during a trial, their timing, and visual properties. That table will refer to this `id` in order to link those descriptions (typically multiple lines in the Stimulus table) to a unique row in the `Response` table."
+          ]
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "study_name",
+          "type": "string",
+          "requirement": "required",
+          "description": "The name of the study or experiment."
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "group_name",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Subjects may be assigned to different groups. Typically, different groups will have different experiences within a study."
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "agent_id",
+          "type": "string",
+          "requirement": "required",
+          "description": "A unique identifier assigned to the agent (typically person) generating the responses. This ID tracks their participation and responses throughout the study. See `Agent` table."
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "session_id",
+          "type": "integer",
+          "requirement": "required",
+          "description": "When there are multiple sessions, this variable indicates the order of each session (i.e., the first session completed by the subject has `session_index` = 1, the second session has `session_index` = 2; even if the second session is an exact repetition of the first one.",
+          "range": "index of session within subject.",
+          "notes": [
+            "We currently don’t use session_name, session_id and session_repetition in this table."
+          ]
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "activity_index",
+          "type": "index",
+          "requirement": "optional",
+          "description": "When subjects complete multiple activities (e.g., a cognitive test followed by a questionnaire), this variable indicates the order of each activity (i.e., the first activity completed by the subject has `activity_index` = 1, the second session has `activity_index` = 2; even if the second activity is an exact repetition of the first one.",
+          "range": "1-based index of activity within the subject-level data.",
+          "notes": [
+            "See `Studyflow` table for more details."
+          ]
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "language",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The language the task was completed in, expressed as a two-letter code within the [ISO_639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "instrument_id",
+          "type": "string",
+          "requirement": "required",
+          "description": "The unique identifier of the instrument used for collecting data (e.g., the name of the computer script used to run the test). Unique in the `Instrument` table and corresponding files in the `instruments/` folder.",
+          "range": "`id` in the `Instrument` table."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "instrument_repetition",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of times this particular instrument has already been completed anytime in the past by this particular subject in this study. This variable has a value 0 the first time an instrument is used.",
+          "range": "0-based"
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "timeline_id",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Timelines are specific parameterization of an instrument and their identifiers are unique within the corresponding table for the instrument in the `instruments/` folder."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "timeline_repetition",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of times this particular timeline has already been completed anytime in the past by this particular subject in this study. This variable has a value 0 the first time a timeline is completed.",
+          "range": "0-based"
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "multitask_type",
+          "type": "enum",
+          "requirement": "required",
+          "description": "Subjects may be required to perform multiple tasks at the same time. This variable indicates the type of multitasking required.",
+          "range": "- Empty: No multitasking, i.e., single-tasking. - `concurrent`: There are two independent tasks that need to be completed in parallel. - `compound`: The task requires multiple successive stages or involves tasks that are dependent/coupled.",
+          "notes": [
+            "If no multitasking was involved, leave this field blank.",
+            "This characterization of `multitasking_type` is rudimentary and will likely evolve in the future."
+          ]
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "task_index",
+          "type": "index",
+          "requirement": "optional",
+          "description": "when `multitask_type` is not empty, `task_index` refers to each of the individual tasks. For example, for auditoy-visual dual N-back, `task_index=1` is the auditory task and `task_index=2` is the visual task.",
+          "range": "1-based index."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "job_type",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The general type of operation the subject needs to perform. The job typically is expressed as a verb (e.g., \"recall\", \"sort\") and can be the same for different instruments (e.g., Digit Span test and Spatial Span test both have a job of type \"recall-forward\")."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "job_description",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The more specific description of a job, which gives more information about what the participant sees and has to do. Whereas the `job_type` typically uses only verbs and adjectives, the `job_description` also contains nouns (e.g., “recall-digits-forward”, “recall-letters-backward”)."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "job_repeat",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Whether this trial's job has not been seen before in this timeline (i.e., specific version of the instrument).",
+          "range": "- `new`: The job has never been seen before by this subject in the current study. - `repeat`: The job is the same as the previous trial. - `switch`: The job is different from the previous trial but has been seen prior in the timeline."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "block_index",
+          "type": "index",
+          "requirement": "required",
+          "description": "Refers to the order in which this block has been experienced by the subject. When there are multiple blocks, this variable indicates the order of each block (i.e., the first block completed by the subject has `block_index=1`, the second block has `block_index=2`, even if the second block is an exact repetition of the first one).",
+          "range": "1-based index of the block within the timeline",
+          "notes": [
+            "In questionnaires, `block_index` may refer to distinct pages where each page may contain multiple questions."
+          ]
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "block_name",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The name of a particular block in a timeline. If the same block is completed twice in a row, they would have different `block_index` values (1 and 2, respectively) but they would have the same `block_name` (e.g., “NB_timeline1_block1”). More details about the `block_name` is available in the `Instrument` table."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "block_type",
+          "type": "enum",
+          "requirement": "required",
+          "description": "Specifies the experimental role of the block (e.g., tutorial, practice, test, instruction).",
+          "range": "- `tutorial`: A simplified version of the test designed to teach participants how the test works. - `practice`: Typically identical to the main test blocks but are used to get subjects accustomed to the task in a no-stakes environment. - `test`: Primary blocks used to measure the desired behaviors. - `instruction`: Presents written and/or visual instructions to the subject."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "transformation_name",
+          "type": "string",
+          "requirement": "required",
+          "description": "Refers to the specific events-to-trials function used to construct rows of this table from raw events. The transformation (or projection in DDD terminology) embodies the definition of a trial for a particular task. The transformer name refers to a code in the format of a function `f(trial_state, event) => trial_state`, where `event` is the event occurred during the performance of the task, and `trial_state` is the data stored for the trial. The final state of a trial is thus the result of applying a sequence of projections such that `trial = f(f(f(initial()), e), e), e)`.'",
+          "notes": [
+            "- The transformation/projection encapsulates the domain rules that define a \"trial\" for a given task. It defines what constitutes a \"trial\"."
+          ]
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "trial_index",
+          "type": "id",
+          "requirement": "required",
+          "description": "Sequential identifier representing number of times transformation rule to the events occurred. It increases with each re-computation of the trial based on updated or newly received events.",
+          "range": "Preferably 1-based integer index.",
+          "notes": [
+            "This field emphasizes order of trials and alignment with projection-based definition of trials. A more complete name would be `projection_index` or `pojected_trial_index`. For brevity, BDM uses `trial_id` instead."
+          ]
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "episode_index",
+          "type": "index",
+          "requirement": "optional",
+          "description": "Episodes are temporally distinct bins of time (no overlap and discrete). The binning of the time into successive episodes depends on the task; it is mostly used and necessary to group data in cases where two distinct trials occurred at the same time (e.g., dual N-back).",
+          "range": "1-based interger index."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "trial_start_datetime",
+          "type": "datetime",
+          "requirement": "required",
+          "description": "The the first event of the trial occured."
+        },
+        {
+          "categories": [
+            "Task"
+          ],
+          "name": "trial_seed",
+          "type": "integer | string",
+          "requirement": "optional",
+          "description": "Random seed used in the trial (if any)."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_index",
+          "type": "list[index]",
+          "requirement": "optional",
+          "description": "Indexes in chronological (or spatial) order the stimuli shown within an instrument (counting one stimulus per response). `stimulus_index` may for instance be used to refer to the nth question asked within a questionnaire.",
+          "notes": [
+            "Use semicolon-separated indices if more then one stimulus were presented, e.g., `1;2;3`."
+          ]
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_id",
+          "type": "integer",
+          "requirement": "required",
+          "description": "Is a unique identifier for the (unitary, set or sequence of) stimuli presented during a trial; if those exact same stimuli are repeated in a different trial, that trial would have the same value for stimulus_id. stimulus_id may also be used to refer to a specific message or question in a questionnaire."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_type",
+          "type": "enum",
+          "requirement": "required",
+          "description": "BDM distinguishes the following stimulus types: messages and questions",
+          "range": "- `message`: The stimulus is a message shown to subjects (e.g., task instructions). - `question`: The stimulus may consist of text, images and/or sounds; they require subjects to make a decision based on the content of the stimulus."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_onset",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Duration between the start of the trial and the appearance of the stimulus, in seconds.",
+          "range": "In seconds"
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_panel_count",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of panels or screen areas stimuli may appear on during the trial. For example, in a task where stimuli to be compared are presented on the left and right side of the screen, stimulus_panel_count = 2."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_structure",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "We distinguish three stimulus structures: unitary, set, sequence",
+          "range": "- `unitary`: Only one stimulus is shown, alone. - `set`: Many stimuli are shown, either at the same time or not; order does not matter. - `sequence`: Multiple stimuli are shown, either at the same time or not; order does matter (order may be indicated by the order of presentation or by a digit for example)."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_structure_source_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Indicates the type of method used to generate the stimulus_structure (this is relevant when a trial displays a sequence of or set of stimuli): none, preset, generator",
+          "range": "- `none`: when stimulus_structure == unitary.\", - `preset`: The structure of stimuli is hard coded in a file. - `generator`: A procedure was used to generate the stimulus_structure."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_structure_source",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Refers to the specific generator used to produce the stimulus_structure (e.g., sequence of digits in a digit span test). When no generator was used, this variable has a value of none."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_set_size",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of different values each presented stimulus could have taken. This value gives an indication of the complexity of the stimulus space. When this number is large we set this variable to infinity, when for any reason it was not computed, it has a value of NA.",
+          "notes": [
+            "To specify \"infinity\" in a CSV file we use +Inf and -Inf; these are correctly recognized in R (tidyverse) and Python (pandas) as being valid numbers rather than strings."
+          ]
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_count",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of stimuli shown to the participant during the trial.",
+          "range": "This should match number of stimuli in stimulus_id"
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_source_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "A stimulus is typically created using a particular procedure/algorithm (\"generator\") or is sampled from a particular set (\"set\"). This variable indicates which of these two applies for the current stimulus.",
+          "range": "- \"set\":\"stimulus is sampled from a fixed set of stimuli.\" - \"generator\": \"stimulus is created using a procedure/algorithm.\""
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_source",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Refers to the specific generator or set the stimulus belongs to. Stimuli that stem from the same source have the same data scheme and could thus be described in a table named after stimulus_source (i.e., stimulus_source indicates which table contains the full information about the stimulus; e.g., \"digit1to9\")."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_index_in_source",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Index of the stimulus within the table referred to by stimulus_source. : For example, if stimulus_source == \"digit1to9\", stimulus_index_in_source = 1 refers to \"1\" while for stimulus_source == \"LettersAtoD\", stimulus_index_in_source = 1 refers to \"A\".",
+          "notes": [
+            "It is not because a particular stimulus_source is used in a given timeline that all possible stimuli of that source are displayed to the user. For example, the AX-CPT may use \"upper-case-letters\" but only use a subset of those letters (e.g., \"A\", \"B\", \"X\", \"Y\"). Whenever possible, we specify the most relevant/specific set (e.g., \"digit1to9\" rather than \"digit\")."
+          ]
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_position_index",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Refers to discrete positions on the screen the stimulus may appear on. The set and ordering of possible positions depends on the test. Whenever possible, it follows a natural order (left to right, top to bottom), but in free-form layouts, indices are arbitrary."
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_description",
+          "type": "string",
+          "requirement": "optional",
+          "description": "A human readable, compact description of the main aspects of the stimulus. The description for a given stimulus depends on the task but follows a specific template for a given task. Because of this, it looks like the stimulus_description could be \"parsed\" and \"tidied\"---however, this is not the intention; parsed/tidied data will be available in other tables; description is for human readability and facilitates the understanding of the data.",
+          "notes": [
+            "In some cases, when stimuli are too complex or can't be precisely described, a summary of all stimuli is given instead."
+          ]
+        },
+        {
+          "categories": [
+            "Stimulus"
+          ],
+          "name": "stimulus_role",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "A stimulus may play different roles within a trial. Below is a list of some possible roles:",
+          "range": "- \"target\": \"A stimulus the subject must process and which should trigger the completion of the response (e.g., classify, reach, memorize) if the subject is doing the task as intended. Note that in some cases (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click the button. In this case, the stimulus that triggered the decision to NOT click the button is still a *target*.\" - \"non_target\": \"A stimulus the subject must process but which does not trigger the completion of the response (e.g., the first two stimuli in a 2-back test).\" - \"distractor\": \"A stimulus the subject should not process at all (i.e., ignore) and which is unrelated to the correct execution of the task.\" - \"location_cue\": \"A stimulus giving a spatial location information that subjects could use to improve their performance.\" - \"job_specifier\": \"A stimulus specifying which job the subject should perform.\" - \"stop_signal\": \"A stimulus signaling the participant he should abort his current action.\" - \"probe\": \"A stimulus indicating about which stimulus to respond.\""
+        },
+        {
+          "categories": [
+            "Option"
+          ],
+          "name": "option_source_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "A set of options is typically created using a particular procedure/algorithm (“generator”) or is sampled from a particular set (“set”). This variable indicates which of these two applies for the current options."
+        },
+        {
+          "categories": [
+            "Option"
+          ],
+          "name": "option_source",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Refers to the specific generator or set that determined the options on a given trial. Option that stem from the same source have the same data scheme and could thus be described in a table named after option_source (i.e., option_source indicates which table contains the full information about the option set).",
+          "notes": [
+            "While there is a stimulus_index_in_source to refer to the particular stimulus that was used, we don’t have an equivalent opiton_index_in_source since all options are displayed. Instead, we use response_index and expected_response_index to refer to a particular option within the set of options."
+          ]
+        },
+        {
+          "categories": [
+            "Option"
+          ],
+          "name": "option_count",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of options the participant can choose from on a given trial."
+        },
+        {
+          "categories": [
+            "Option"
+          ],
+          "name": "option_id",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Is a unique identifier for the option (set or generator) used on a given trial."
+        },
+        {
+          "categories": [
+            "Option"
+          ],
+          "name": "option_data_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Describes the type of data this option entails. Possible values include:",
+          "range": "- \"nominal\": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - \"ordinal\": \"Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - \"interval\": Ordered values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - \"ratio\": Values with clear distance metrics and absolute zero (e.g., length in cm)."
+        },
+        {
+          "categories": [
+            "Option"
+          ],
+          "name": "measurement_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Describes the type of measurement implied by Option which in turn has implications on how that data should be processed during analysis; takes a value in:",
+          "range": "- \"nominal\": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - \"ordinal\": \"Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - \"interval\": Ordered values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - \"ratio\": Values with clear distance metrics and absolute zero (e.g., length in cm)."
+        },
+        {
+          "categories": [
+            "Input"
+          ],
+          "name": "input_interface_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Refers to the type of interface subjects used to input actions. Possible values include (non-exhaustive):",
+          "range": "- `keyboard`: A keyboard is displayed on the screen. - `buttons`: Dedicated buttons on the screen. - `stimulus-button`: Stimuli serves as buttons. - `text-field`: A text field is displayed on the screen. - `slider`: A slider is displayed on the screen."
+        },
+        {
+          "categories": [
+            "Input"
+          ],
+          "name": "input_action_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Refers to the type of action the subject performs to give a response. Possible values include (non-exhaustive):",
+          "range": "- \"mouse-click\" - \"mouse-release\" - \"key-press\" - \"key-release\" - \"mouse-drag\" - \"touch\" - \"swipe\"",
+          "notes": [
+            "The type of input_action determines the structure of detailed response data (i.e., mouse-click data is different from key-press data)."
+          ]
+        },
+        {
+          "categories": [
+            "Input"
+          ],
+          "name": "input_count",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of inputs (i.e., actions) the user made during the trial.",
+          "notes": [
+            "For mouse-drag, it corresponds to the number of drag points that have been sampled during the drag-and-drop."
+          ]
+        },
+        {
+          "categories": [
+            "Expectation"
+          ],
+          "name": "expected_response_option_index",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The index of the option the subject is expected to choose from the set of options.",
+          "notes": [
+            "When expected_response_index = 0, it means that the subject should not respond at all.",
+            "Sometimes stimuli serve both as stimuli and as response options as subjects have to click on a particular stimuli to give their response (e.g., spatial span, odd one out). It is convenient in those cases to use stimulus_position_index to order/index the options (i.e., option_index == stimulus_position_index) and consequently also the responses."
+          ]
+        },
+        {
+          "categories": [
+            "Expectation"
+          ],
+          "name": "expected_response_description",
+          "type": "string",
+          "requirement": "optional",
+          "description": "A description of the expected response using the same convention as response_description."
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_structure",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The structure of the response required by the subject; can take values in:",
+          "range": "- `unitary`: The subject provides a single input (e.g., chooses option *same*). - `set`: The subject provides a set of information, and the order does not matter (e.g., list words that start with the letter *A*). - `sequence`: The subject provides a sequence of information, and the order matters (e.g., a sequence of memorized digits in their order of appearance).",
+          "notes": [
+            "Note that the distinction between set and sequence refers to the importance of order information to evaluate if the response is correct or not; a response with a set structure may unfold over time (each piece of information is given in a particular temporal order) and it may be of scientific interest to take into account that order; however, the order itself is not important within the task itself. For example, in the [MOT task](https://en.wikipedia.org/wiki/Multiple_object_tracking) one may ask subjects to point to all dots that hide a token. If subjects point to all such dots they will be correct no matter in which order the dots were clicked in."
+          ]
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_count",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Each trial contains by definition only one response. However, when response_structure is other than unitary, a response comprises multiple pieces of information (e.g., “3-5-7” could be one response in the digit span task and this response contains three components, namely “3”, “5” and “7”). response_count refers to the number of components that make up a response (not the number of responses within a trial).",
+          "notes": [
+            "response_count is different from input_count; a subject may in some cases change their response multiple times before submitting the final response. In such cases, there would be many more inputs than there are components to the final response.",
+            "While we have stimulus_set_size we currently don’t have a response_set_size, but we do have option_count and response_count."
+          ]
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_option_index",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The index of the option the participant chose, starting from 1.",
+          "notes": [
+            "response_option_index = 0 means the subject chose none of the options (e.g., a “no-go” response in a Go/No-go task).",
+            "response_index can be directly compared to expected_response_index.",
+            "response_index refers to an entry in the Option table (i.e., there is no Response table)."
+          ]
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_description",
+          "type": "string",
+          "requirement": "optional",
+          "description": "A description of participant’s response; typically the description of the option that was chosen.",
+          "notes": [
+            "response_description can be directly compared to expected_response_description."
+          ]
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_numeric",
+          "type": "float",
+          "requirement": "optional",
+          "description": "A numeric value associated with a particular response; this could be a numeric value entered directly by the subject or the numeric meaning of a selected option (for example, the choice of option \"Never\" may be associated with the numeric value of 0). Note that this variable describes the subject's response; it does not describe the value (e.g., correctness or goodness) that is associated with that response."
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_time",
+          "type": "float",
+          "requirement": "optional",
+          "description": "The duration, in seconds, between the earliest possible time a response could have been completed and the moment that response was actually completed (and NOT when it was initiated)."
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_datetime",
+          "type": "datetime",
+          "requirement": "optional",
+          "description": "The datetime corresponding to the completion of the response."
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_validation_time",
+          "type": "float",
+          "requirement": "optional",
+          "description": "In some cases, subjects may need to press an extra key to validate previous responses. When relevant, this variable may encode this duration."
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_initiation_time",
+          "type": "float",
+          "requirement": "optional",
+          "description": "In some cases (e.g., a reaching movement) it might be useful to encode when a response was initiated."
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "response_skipped",
+          "type": "boolean",
+          "requirement": "optional",
+          "description": "In some cases (e.g., in some questionnaires), subjects have the option to skip a question."
+        },
+        {
+          "categories": [
+            "Response"
+          ],
+          "name": "timed_out",
+          "type": "boolean",
+          "requirement": "optional",
+          "description": "Some tasks require subjects to give a response within a certain time limit. When subjects fail to respond before that time runs out, timed_out is set to TRUE."
+        },
+        {
+          "categories": [
+            "Evaluation"
+          ],
+          "name": "accuracy",
+          "type": "float",
+          "requirement": "optional",
+          "description": "A task-dependent accuracy measure ranging from 0 to 1 (inclusive)."
+        },
+        {
+          "categories": [
+            "Evaluation"
+          ],
+          "name": "correct",
+          "type": "boolean",
+          "requirement": "optional",
+          "description": "Indicates whether the response matches the expected response (i.e., correct = TRUE) or not (i.e., correct = FALSE)."
+        },
+        {
+          "categories": [
+            "Evaluation"
+          ],
+          "name": "score",
+          "type": "float",
+          "requirement": "optional",
+          "description": "A numeric value associated with a particular response in a given context. This variable may be used to compute a performance metric or a questionnaire level index (e.g., a well-being score)."
+        },
+        {
+          "categories": [
+            "Evaluation"
+          ],
+          "name": "evaluation_label",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "There are several labels that can be assigned to a given response to specify what that response means in terms of evaluation within a task. The most general terms are \"correct” and \"error\" (which are already given by the correct variable). There are however more specific sets of terms that may apply in different contexts. For example, in a signal detection task, it is common to use labels from the signal detection theory framework (i.e., “hit”, “miss”, “false alarm”, “correct rejection”). In other contexts, researchers might use terms like “omission” or “commission” errors or even things like “perseveration” error (e.g., in the Wisconsin Card Sorting Test). Note that these terms are not always well defined or exclusive. For example, a “hit” is also a “correct” response and a “false alarm” may be synonymous to “commission error”. Whenever possible use the more specific terms (i.e., always use “hit” rather than “correct” when applicable). Here are few evaluation labels that are commonly used:",
+          "range": "- `correct`: The response is correct. - `error`: The response is incorrect. - `hit`: The stimulus was *present* and the subject correctly responded *present*. - `miss`: The stimulus was *present* and the subject correctly responded *absent*. - `fa`: The stimulus was *absent* and the subject correctly responded *present*. - `cr`: The stimulus was *absent* and the subject correctly responded *absent*."
+        },
+        {
+          "categories": [
+            "Feedback"
+          ],
+          "name": "feedback_description",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Lists the different kinds of feedback that were shown on a given trial. When multiple types of feedback were used, feedback will list them using `;` as a separator. If a given type of feedback was shown multiple times during a trial, that feedback type is listed only once (i.e., feedback_description does NOT represent the sequence of feedbacks). The possible values for feedback are:",
+          "range": "- `none`: No feedback was shown. - `expected_response`: Feedback indicated what the correct response would have been. - `explanation`: Feedback explains *why* a certain option is the correct one. - `correctness_on_option`: \"Feedback indicates (on the option itself) if the option chosen by the participant was the correct one (e.g., in green), or not (e.g., in red). - `correctness_on_screen`: \"Feedback displayed on the screen center indicates if the response to the current trial was correct or not (e.g., using a green check or a red cross).",
+          "notes": [
+            "This list is not exhaustive and characterizing feedback in the future will involve more variables (e.g., separating the type of information shown (e.g., correctness) and how it is shown (“on_option” versus “on_screen”).",
+            "NOTE2: We don’t consider here as “feedback”, the kind of feedback that is used in UI to confirm to users that a button has indeed been clicked."
+          ]
+        },
+        {
+          "categories": [
+            "Outcome"
+          ],
+          "name": "outcome_description",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Describes the observable consequences of the subject's response (e.g., \"the opened box is empty\")."
+        },
+        {
+          "categories": [
+            "Outcome"
+          ],
+          "name": "outcome_numeric",
+          "type": "float",
+          "requirement": "optional",
+          "description": "A numeric value describing the observable consequences of the subject's response (e.g., +3 points)."
+        },
+        {
+          "categories": [
+            "Accessory"
+          ],
+          "name": "additional_measures",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Indicates whether additional measures have been recorded during this trial and if so what kind of measures they are. Possible values include (non-exhaustive):",
+          "range": "- `mouse_trajectories` - `fmri` - `eye_tracking` - `heart_rate`",
+          "notes": [
+            "Leave this field empty if no additional measures were recorded for this specific response."
+          ]
+        },
+        {
+          "categories": [
+            "Experimental Design"
+          ],
+          "name": "adaptive_method_name",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Specifies the adaptive procedure used to modify instrument parameters in response to subject performance (e.g., `staircase`)."
+        },
+        {
+          "categories": [
+            "Experimental Design"
+          ],
+          "name": "adaptive_method_config",
+          "type": "string",
+          "requirement": "optional",
+          "description": "More detailed configuration for the adaptive method, including initial values, step sizes, and termination criteria.",
+          "notes": [
+            "For example, `1up-2down`. The 1-up, 2-down is a common adaptive staircase procedure used to estimate a subject's threshold or sensitivity. After a correct response, the difficulty level is increased, and after two incorrect responses, the difficulty level is decreased."
+          ]
+        },
+        {
+          "categories": [
+            "Experimental Design"
+          ],
+          "name": "adaptive_parameter_name",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Specific instrument parameter that is dynamically modified based on the subject's performance."
+        },
+        {
+          "categories": [
+            "Experimental Design"
+          ],
+          "name": "adaptive_parameter_value",
+          "type": "any",
+          "requirement": "optional",
+          "description": "The specific value of the instrument parameter that was used for this trial. This value is updated as the adaptive algorithm adjusts the parameter based on the subject's responses.",
+          "range": "Data type depends on the type of the adaptive parameter, as defined in `adaptive_parameter_name`)"
+        },
+        {
+          "categories": [
+            "Experimental Design"
+          ],
+          "name": "adaptive_parameter_value_next",
+          "type": "any",
+          "requirement": "optional",
+          "description": "The next value of the adaptive parameter that will be used in the subsequent trial, as determined by the adaptive algorithm.",
+          "range": "Data type depends on the type of the adaptive parameter, as defined in `adaptive_parameter_name`)"
+        }
+      ]
+    },
+    {
+      "name": "Stimulus",
+      "label": "Stimulus",
+      "description": "Describes each of the stimuli that were shown during an trial.",
+      "notes": [
+        "Each row of `Stimulus` table corresponds to a stimulus in a trial. Each trial can contain different number of stimuli."
+      ],
+      "fields": [
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "stimulus_id",
+          "type": "PRIMARY KEY",
+          "requirement": "required",
+          "description": "Primary key of the `Stimulus` table. Reference to this identifier in other tables are thus named `stimulus_id`.",
+          "range": "Each row in this table has a unique `id`.",
+          "notes": [
+            "If the same stimulus is shown at two different times in a trial, those two instances will have their own row in the `Stimulus` table, each with its own `id`.",
+            "Make sure to refer to this field as `stimulus_id` rather than `id` When joining tables. This also applies to all the `id` fields; they are named `id` within their own context/table, but `<context/table>_id` when addressed from other tables. For example, `X_id` in a table refers (hence a foreign key) to the `id` column in the X table."
+          ]
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "trial_id",
+          "type": "id",
+          "requirement": "optional",
+          "description": "Refers to the `trial_index` in the `Response` table and indicates in which trial this stimulus was shown.",
+          "range": "`trial_id` in the `Response` table of the same agent/session/activity/attempt"
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "response_id",
+          "type": "id",
+          "requirement": "required",
+          "description": "Refers to the `response_id` in the `Response` table and indicates for which response this stimulus was shown.",
+          "range": "`response_id` in the `Response` table of the same agent/session/activity/attempt"
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "object_id",
+          "type": "string",
+          "requirement": "optional",
+          "description": "A stimulus is defined by a set of features. This variable is used to identify each time the same stimulus features were used.",
+          "notes": [
+            "For example, if the same white digit \"3\" is shown in a digit span sequence, all those instances would have the same `object_id` although they would have different `id`s (as they appeared at different times)."
+          ]
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "presentation_id",
+          "type": "string",
+          "requirement": "optional",
+          "description": "In a multitasking setting, a particular instance of a stimulus (e.g., the current letter \"A\") may be used by multiple tasks at the same time (e.g, in the dual N-back task). Because these are different trials, they will have different `trial_id` values and hence will have different rows in the `Stimulus` table. We use `presentation_id` to indicate that a given stimulus is in fact the same instance across those trials."
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "index_in_trial",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Refers to individual stimuli within the sequence or set of stimuli shown during a trial."
+        },
+        {
+          "categories": [
+            "When"
+          ],
+          "name": "onset",
+          "type": "float",
+          "requirement": "required",
+          "description": "Duration between the start of the trial and the appearance of the stimulus, in seconds.",
+          "range": "In seconds"
+        },
+        {
+          "categories": [
+            "When"
+          ],
+          "name": "duration",
+          "type": "float",
+          "requirement": "required",
+          "description": "Describes for how long this stimulus was displayed after its onset, in seconds.",
+          "range": "In seconds",
+          "notes": [
+            "When the stimulus is shown using an animation, `duration` covers the complete period between the start of the animation and the end of the animation."
+          ]
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "panel_id",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Identifier of the panel this stimulus is displayed over."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "X coordinates of the stimulus on the screen in pixels.",
+          "notes": [
+            "In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd)."
+          ]
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Y coordinates of the stimulus on the screen in pixels."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "X coordinates of the stimulus on the screen expressed as a fraction of the screen width.",
+          "range": "0 to 1 (inclusive)"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Y coordinates of the stimulus on the screen expressed as a fraction of the screen height.",
+          "range": "0 to 1 (inclusive)"
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "description",
+          "type": "string",
+          "requirement": "required",
+          "description": "A human readable, compact description of the main aspects of the stimulus. The description for a given stimulus depends on the task but follows a specific template for a given task. Because of this, it looks like the `description` could be parsed and converted into a more structured format---however, this is not the intention; structured data will be available in other tables; here, description is for human readability and facilitates the understanding of the data."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "source",
+          "type": "string",
+          "requirement": "required",
+          "description": "Refers to the specific generator or set the stimulus belongs to.",
+          "notes": [
+            "Stimuli that come from the same source have the same data scheme and could thus be described in a table named after the `stimulus_source`. `stimulus_source` indicates which table contains the full information about the stimulus; e.g., \"digits1to9\".",
+            "One could include a `source_count` variable here that indicates how many different stimuli there are in the set; but it's better stored in the table that contains information about that stimulus source."
+          ]
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "source_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "A stimulus is typically created using a particular procedure/algorithm (\"generator\") or is sampled from a particular set (\"set\"). This variable indicates which of these two applies for the current stimulus.",
+          "range": "- `set`: stimulus is sampled from a fixed set of stimuli. - `generator`: \"stimulus is created using a procedure/algorithm."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "index_in_source",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "When a stimulus is picked from a particular set (e.g., \"digits1to9\"), this index refers to the index within that set.",
+          "notes": [
+            "In addition to `index_in_source`, `stimulus_id` can also be used to look up further information about the stimulus in the source."
+          ]
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "role",
+          "type": "enum",
+          "requirement": "required",
+          "description": "Describe the role that the stimulus plays in the trial, e.g., \"target\".",
+          "range": "- `target`: A stimulus the agent must process and which should trigger the completion of the response (e.g., classify, reach, memorize) if the agent is doing the task as intended. In some cases (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click the button. In this case, the stimulus that triggered the decision to NOT click the button is still a `target`. - `non_target`: A stimulus the agent must process but which does not trigger the completion of the response (e.g., the first two stimuli in a 2-back test). - `distractor`: \"A stimulus the agent should not process at all (i.e., ignore) and which is unrelated to the correct execution of the task. - `location_cue`: A stimulus giving a spatial location information that agents could use to improve their performance. - `job_specifier`: A stimulus specifying which job the agent should perform. - `stop_signal`: \"A stimulus signaling the agents that they should abort current action. - `probe`: A stimulus indicating about which stimulus to respond."
+        },
+        {
+          "categories": [
+            "How"
+          ],
+          "name": "animation",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Describes the animation used to display a specific stimulus in a human-readable format. For example, \"fadeIn 3s\" indicates a 3-second fade-in animation.",
+          "notes": [
+            "To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common animations (e.g., \"3s linear slide-in\")."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Option",
+      "label": "Option",
+      "description": "Describes each option that a subject could choose from in a trial.",
+      "notes": [
+        "Note that in some tasks, the options may change within a trial after each input (e.g., serial self-ordered search task); therefore the options are optionally indexed by `input_index`."
+      ],
+      "fields": [
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "option_id",
+          "type": "PRIMARY KEY",
+          "requirement": "required",
+          "description": "Primary key of the `Option` table. Reference to this identifier in other tables are thus named `option_id`.",
+          "range": "Each row in this table has a unique `id`",
+          "notes": [
+            "If the same option is shown at two different times in a trial, those two instances will have their own row in the * Option* table, each with its own `id`."
+          ]
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "trial_index",
+          "type": "id",
+          "requirement": "required",
+          "description": "Refers to the `trial_index` in the `Response` table and indicates in which trial this option was shown.",
+          "range": "`trial_index` in the `Response` table for the same subject/session/activity"
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "response_id",
+          "type": "id",
+          "requirement": "optional",
+          "description": "Refers to the `response_id` in the `Response` table and indicates for which response this option was shown.",
+          "range": "`response_id` in the `Response` table of the same subject/activity"
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "index_in_trial",
+          "type": "index",
+          "requirement": "optional",
+          "description": "Indexing each of the options within the set of options that were available to subjects on a given trial.",
+          "range": "1-based indices",
+          "notes": [
+            "If the presented options have no specific temporal or spatial order, leave this field empty or assign the same index to all options, e.g., `index_in_trial=1`."
+          ]
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "object_id",
+          "type": "string",
+          "requirement": "optional",
+          "description": "An option is defined by a set of features. This variable is used to identify each time the same features were used. For example, if the same white digit \"3\" is used as an option in the Digit Span task, all those instances would have the same `object_id` although they would have different `id`s (as they appeared at different times)."
+        },
+        {
+          "categories": [
+            "When"
+          ],
+          "name": "onset",
+          "type": "float",
+          "requirement": "required",
+          "description": "Duration between the start of the trial and the moment the option was displayed or activated, in seconds.",
+          "range": "In seconds"
+        },
+        {
+          "categories": [
+            "When"
+          ],
+          "name": "duration",
+          "type": "float",
+          "requirement": "required",
+          "description": "How long the option was displayed or active in seconds, starting from the `onset`, in seconds.",
+          "range": "In seconds"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "panel_id",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Identifier of the pane this option was displayed over."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_screen",
+          "type": "float",
+          "requirement": "optional",
+          "description": "X coordinates of the option component on the screen in pixels.",
+          "notes": [
+            "In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd)."
+          ]
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_screen",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Y coordinates of the option component on the screen in pixels."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "X coordinates of the option component on the screen expressed as a fraction of the screen width.",
+          "range": "0 to 1 (inclusive)."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Y coordinates of the option component on the screen expressed as a fraction of the screen height.",
+          "range": "0 to 1 (inclusive)."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "description",
+          "type": "string",
+          "requirement": "required",
+          "description": "A human readable, compact description of the main aspects of the option. The description for a given option depends on the task but follows a specific template for a given task. Because of this, it looks like the option description could be parsed---however, this is not the intention; structured, parsed data will be available in other fields; description is for human readability and facilitates the understanding of the data."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "value",
+          "type": "float",
+          "requirement": "optional",
+          "description": "A numeric value associated with a particular response option; typically indicating the \"worth\" of a response (e.g., `value=1` for the correct response)."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "source",
+          "type": "string",
+          "requirement": "required",
+          "description": "Refers to the specific generator or set from which the option originates. Options sharing the same source have the same data structure and can be thus collectively described in a table named after `option_source` (e.g., \"digit1to9\").",
+          "notes": [
+            "The `option_source` specifies the table or file that provides complete details about the option. For instance, `option_source=digit1to9` indicates a source containing information on digits 1 to 9."
+          ]
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "source_type",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "An option is typically created using a particular procedure/algorithm or is sampled from a particular set. This variable indicates which of these two applies for the current option.",
+          "range": "- `set`: option is sampled from a fixed set of options. - `generator`: option is created using a procedure/algorithm."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "index_in_source",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "When a option is picked from a particular set (e.g., `digits1to9`), this index refers to the index within that set."
+        },
+        {
+          "categories": [
+            "How"
+          ],
+          "name": "animation",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Describes the animation used to display a specific option in a human-readable format. For example, \"fadeIn 3s ease-in-out\" indicates a 3-second fade-in animation.",
+          "notes": [
+            "To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common animations (e.g., \"3s linear slide-in\")."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Input",
+      "label": "Input",
+      "description": "A detailed log of all inputs and clicks recorded during the trial.",
+      "fields": [
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "input_id",
+          "type": "PRIMARY KEY",
+          "requirement": "required",
+          "description": "Primary key; each input or click has its own identifier value that is unique within the table."
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "response_id",
+          "type": "id",
+          "requirement": "required",
+          "description": "Indexing all the clicks that occurred within a given trial; ranging from 1 to `input_count` in the corresponding `Response` table."
+        },
+        {
+          "categories": [
+            "Context"
+          ],
+          "name": "response_element_index",
+          "type": "index",
+          "requirement": "optional",
+          "description": "Indicates which of the clicks is used and in what order to form the actual response in the response table when `response_structure` is \"sequence\" or \"set\".",
+          "range": "1 to `input_count` in the corresponding row of the `Response` table.",
+          "notes": [
+            "This needs to be here rather than in `Option` table, because the same option can be clicked multiple times and either serve or not for the response depending on the order of the clicks. For example, in the Digit Span test we could have the response of \"3;5;7\" on a particular trial. This might correspond to > - `option.description` = [\"3\", \"4\", \"delete\", \"delete\", \"3\", \"5\", \"7\", \"enter\"] > - `click.response_element_index` = [NA, NA, NA, NA, 1, 2, 3, NA]"
+          ]
+        },
+        {
+          "categories": [
+            "When"
+          ],
+          "name": "onset",
+          "type": "float",
+          "requirement": "required",
+          "description": "Duration between the start of the trial and the moment the mouse button press occured, in seconds.",
+          "range": "seconds"
+        },
+        {
+          "categories": [
+            "When"
+          ],
+          "name": "duration",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Describes for how long the mouse button was pressed, in seconds.",
+          "range": "seconds"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "X coordinates of the click relative to the left edge of the screen in pixels.",
+          "range": "pixels"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Y coordinates of the click relative to the top edge of the screen in pixels.",
+          "range": "pixels"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "X coordinates of the click relative to the left edge of the screen expressed as a fraction of the screen width.",
+          "range": "0 to 1 (inclusive)."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Y coordinates of the click relative to the top edge of the screen expressed as a fraction of the screen height.",
+          "range": "0 to 1 (inclusive)."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "object_type",
+          "type": "enum",
+          "requirement": "required",
+          "description": "Describes the type of object that was clicked on (e.g., \"button\")."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "object_name",
+          "type": "string",
+          "requirement": "required",
+          "description": "The human-readable name of the object that was clicked on (e.g., \"sos_box_1_3\")."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "is_object_enabled",
+          "type": "boolean",
+          "requirement": "optional",
+          "description": "Indicates whether the object that was clicked on was enabled (clickable) or not."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "object_state",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Describes the state the object was in *before* it was clicked on. The meaning of \"state\" depends on the particular task (e.g., \"new empty\")."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "option_id",
+          "type": "id",
+          "requirement": "optional",
+          "description": "If the click is on an option, this variable indicates which option it was.",
+          "range": "Corresponding `option_id` in the `Option` table."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "stimulus_id",
+          "type": "id",
+          "requirement": "optional",
+          "description": "If the click is on a stimulus, this variable indicates which stimulus it was.",
+          "range": "Corresponding `stimulus_id` in the `Stimulus` table."
+        }
+      ]
+    },
+    {
+      "name": "StimulusComponent",
+      "label": "StimulusComponent",
+      "description": "Stimuli can comprise multiple components. This table describes each component of a stimulus.",
+      "fields": [
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "stimulus_id",
+          "type": null,
+          "requirement": "required",
+          "description": "A reference to the primary key `id` of the `Stimulus` table.",
+          "range": "`stimulus_id` in the corresponding `Stimulus` table (same subject/session/activity)."
+        },
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "index",
+          "type": "index",
+          "requirement": "required",
+          "description": "A 1-based index indicating the stacking order of stimulus components. A stimulus component with a higher `index` is displayed on top of those with lower values, similar to CSS z-index property.",
+          "range": "1-based indices",
+          "notes": [
+            "If the presented options have no specific temporal or spatial order, leave this field empty or assign the same index to all options, e.g., `index=1`."
+          ]
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "X coordinates of the stimulus component relative to the left edge of the screen in pixels.",
+          "range": "pixels",
+          "notes": [
+            "In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd)."
+          ]
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Y coordinates of the stimulus component relative to the top edge of the screen in pixels.",
+          "range": "pixels"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "X coordinates of the stimulus component relative to the left edge of the screen expressed as a fraction of the screen width.",
+          "range": "0 to 1 (inclusive)"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Y coordinates of the stimulus component relative to the top edge of the screen expressed as a fraction of the screen height.",
+          "range": "0 to 1 (inclusive)"
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "description",
+          "type": "string",
+          "requirement": "required",
+          "description": "A human readable, compact description of the component."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "symbol_name",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The human-readable name of the displayed symbol."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "symbol_count",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of symbols represented in this component."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "symbol_layout",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "How the symbols are laid out.",
+          "range": "- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` - `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`",
+          "notes": [
+            "If none of the predefined layouts apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook."
+          ]
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "color_name",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The human-readable name of the component color, e.g., `red`.",
+          "notes": [
+            "To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors (e.g., \"lightgray\")."
+          ]
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "color_hex",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional alpha channel for transparency.",
+          "range": "#000000 to #FFFFFF"
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "orientation",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Indicates the symbol orientation.",
+          "range": "- `north`: bottom to top. - `north_east` - `east`: left to right. - `south_east` - `south`: top to bottom. - `south_west` - `west`: right to left - `north_west` - `free`: no specific orientation.",
+          "notes": [
+            "If none of the predefined orientations apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "OptionComponent",
+      "label": "OptionComponent",
+      "description": "Options can comprise multiple components. This table describes each component of an option.",
+      "fields": [
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "index",
+          "type": "index",
+          "requirement": "required",
+          "description": "A 1-based index differentiating each part and indicating the stacking order of them. An option component with a higher `index` is displayed on top of those with lower values, similar to CSS z-index property.",
+          "range": "1-based indices"
+        },
+        {
+          "categories": [
+            "Key"
+          ],
+          "name": "option_id",
+          "type": "id",
+          "requirement": "required",
+          "description": "A reference to the key `option_id` in the `Option` table.",
+          "range": "`option_id` in the corresponding `Option` table (same subject/session/activity)."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "panel_id",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Identifier of the panel this option is displayed over."
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "X coordinates of the option component relative to the left edge of the screen in pixels.",
+          "range": "pixels",
+          "notes": [
+            "In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd)."
+          ]
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_screen",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "Y coordinates of the option component relative to the top edge of the screen in pixels.",
+          "range": "pixels"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "x_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "X coordinates of the option component relative to the left edge of the screen expressed as a fraction of the screen width.",
+          "range": "0 to 1 (inclusive)"
+        },
+        {
+          "categories": [
+            "Where"
+          ],
+          "name": "y_viewport",
+          "type": "float",
+          "requirement": "optional",
+          "description": "Y coordinates of the option component relative to the top edge of the screen expressed as a fraction of the screen height.",
+          "range": "0 to 1 (inclusive)"
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "description",
+          "type": "string",
+          "requirement": "required",
+          "description": "A human readable, compact description of the component."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "symbol_name",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The name of the displayed symbol."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "symbol_count",
+          "type": "integer",
+          "requirement": "optional",
+          "description": "The number of symbols represented in this component."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "symbol_layout",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "How the symbols are laid out.",
+          "range": "- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` - `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`",
+          "notes": [
+            "If none of the predefined layouts apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook."
+          ]
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "color_name",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The human-readable name of the component color, e.g., `red`.",
+          "notes": [
+            "To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors (e.g., \"lightgray\")."
+          ]
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "color_hex",
+          "type": "string",
+          "requirement": "optional",
+          "description": "The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional alpha channel for transparency.",
+          "range": "#000000(00) to #FFFFFF(FF)"
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "orientation",
+          "type": "enum",
+          "requirement": "optional",
+          "description": "Indicates the symbol orientation.",
+          "notes": [
+            "If none of the predefined orientations apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Instrument",
+      "label": "Instrument",
+      "description": "Describes the instrument used for data acquisition.",
+      "notes": [
+        "this table includes information about specific parameterizations of the instruments (i.e., timelines). For example, parameters for the software that executes the presentation of the stimuli and records key presses."
+      ],
+      "fields": [
+        {
+          "categories": [
+            "Identifier"
+          ],
+          "name": "instrument_id",
+          "type": "string",
+          "requirement": "required",
+          "description": "Unique identifier of an instrument. It can be formed by combining name and version (e.g., \"DS_v2024.01\")."
+        },
+        {
+          "categories": [
+            "Identifier"
+          ],
+          "name": "timeline_id",
+          "type": "string",
+          "requirement": "required",
+          "description": "Identifier for a timeline. Timeline is a variant of an instrument with specific parametrization, for the whole experiment or for multiple block of trials (e.g., \"DS_FORWARD\" and \"DS_BACKWARD\" for digit span task). Timelines are configurations that specify instrument parameters."
+        },
+        {
+          "categories": [
+            "Identifier"
+          ],
+          "name": "block_id",
+          "type": "string",
+          "requirement": "required",
+          "description": "Specific parameterization of the instrument for a single block of trials (e.g., \"DS_FORWARD_PRACTICE\" and \"DS_FOWARD_TEST\"). Block-level parameters override timeline-level parameters."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "name",
+          "type": "string",
+          "requirement": "required",
+          "description": "Name of the toolkit (scene, code, or configuration) that is used to collect the data, e.g., \"DS\" for a software that runs digit span task in forward OR backward order. The specific parameterization of the instrument is defined by the \"Timeline\" (e.g., a variant of instrument called \"DS_FORWARD\")."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "version",
+          "type": "string",
+          "requirement": "optional",
+          "description": "Refers to the specific version/build of a particular instrument. We will use a calendar based versioning system ([calver.org](https://calver.org/); e.g., \"v2024.01\")."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "description",
+          "type": "string",
+          "requirement": "optional",
+          "description": "A human readable, compact description of the main aspects of the instrument."
+        },
+        {
+          "categories": [
+            "What"
+          ],
+          "name": "link",
+          "type": "url",
+          "requirement": "optional",
+          "description": "External link, if any, the provides more information about the instrument, e.g., on Cognitive Atlas.",
+          "notes": [
+            "Permanent links, e.g., DOIs, are preferred over particular websites."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/trial/field-definitions.yaml
+++ b/trial/field-definitions.yaml
@@ -1,0 +1,1491 @@
+# Behaverse Trial Schema - Field Definitions
+# Source of truth for the trial tables. Edit this file, then run:
+#   uv run scripts/generate.py
+# Seeded once from behaverse/data-model assets/auto-generated/trials (gsheet export);
+# Quarto/Bootstrap markup was stripped in that relocation.
+
+schema_metadata:
+  name: Behaverse Trial Schema
+  version: '26.0608'
+  namespace: https://behaverse.org/schemas/trial
+  description: Tidy tables describing trial-level behavioral data for cognitive tests and questionnaires,
+    derived from raw events.
+tables:
+- name: Response
+  label: Response
+  description: Main table where each row describes a response in a trial.
+  notes:
+  - The information in this table should be sufficient for most analyses, but more detailed information
+    may be linked from other tables via identifiers (`response_id` and `trial_index`).
+  fields:
+  - categories:
+    - Key
+    name: response_id
+    type: PRIMARY KEY
+    requirement: required
+    description: A unique identifier assigned to responses in temporal order, meaning that larger IDs
+      correspond to more recent responses that occurred later in time. This ID is unique within this table;
+      no two rows share the same value.
+    notes:
+    - This identifier is used by other tables, for example `Stimulus` table which describes in greater
+      detail the sequence of images shown during a trial, their timing, and visual properties. That table
+      will refer to this `id` in order to link those descriptions (typically multiple lines in the Stimulus
+      table) to a unique row in the `Response` table.
+  - categories:
+    - Context
+    name: study_name
+    type: string
+    requirement: required
+    description: The name of the study or experiment.
+  - categories:
+    - Context
+    name: group_name
+    type: string
+    requirement: optional
+    description: Subjects may be assigned to different groups. Typically, different groups will have different
+      experiences within a study.
+  - categories:
+    - Context
+    name: agent_id
+    type: string
+    requirement: required
+    description: A unique identifier assigned to the agent (typically person) generating the responses.
+      This ID tracks their participation and responses throughout the study. See `Agent` table.
+  - categories:
+    - Context
+    name: session_id
+    type: integer
+    requirement: required
+    description: When there are multiple sessions, this variable indicates the order of each session (i.e.,
+      the first session completed by the subject has `session_index` = 1, the second session has `session_index`
+      = 2; even if the second session is an exact repetition of the first one.
+    range: index of session within subject.
+    notes:
+    - We currently don’t use session_name, session_id and session_repetition in this table.
+  - categories:
+    - Context
+    name: activity_index
+    type: index
+    requirement: optional
+    description: When subjects complete multiple activities (e.g., a cognitive test followed by a questionnaire),
+      this variable indicates the order of each activity (i.e., the first activity completed by the subject
+      has `activity_index` = 1, the second session has `activity_index` = 2; even if the second activity
+      is an exact repetition of the first one.
+    range: 1-based index of activity within the subject-level data.
+    notes:
+    - See `Studyflow` table for more details.
+  - categories:
+    - Task
+    name: language
+    type: string
+    requirement: optional
+    description: The language the task was completed in, expressed as a two-letter code within the [ISO_639-1
+      standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+  - categories:
+    - Task
+    name: instrument_id
+    type: string
+    requirement: required
+    description: The unique identifier of the instrument used for collecting data (e.g., the name of the
+      computer script used to run the test). Unique in the `Instrument` table and corresponding files
+      in the `instruments/` folder.
+    range: '`id` in the `Instrument` table.'
+  - categories:
+    - Task
+    name: instrument_repetition
+    type: integer
+    requirement: optional
+    description: The number of times this particular instrument has already been completed anytime in
+      the past by this particular subject in this study. This variable has a value 0 the first time an
+      instrument is used.
+    range: 0-based
+  - categories:
+    - Task
+    name: timeline_id
+    type: string
+    requirement: optional
+    description: Timelines are specific parameterization of an instrument and their identifiers are unique
+      within the corresponding table for the instrument in the `instruments/` folder.
+  - categories:
+    - Task
+    name: timeline_repetition
+    type: integer
+    requirement: optional
+    description: The number of times this particular timeline has already been completed anytime in the
+      past by this particular subject in this study. This variable has a value 0 the first time a timeline
+      is completed.
+    range: 0-based
+  - categories:
+    - Task
+    name: multitask_type
+    type: enum
+    requirement: required
+    description: Subjects may be required to perform multiple tasks at the same time. This variable indicates
+      the type of multitasking required.
+    range: '- Empty: No multitasking, i.e., single-tasking. - `concurrent`: There are two independent
+      tasks that need to be completed in parallel. - `compound`: The task requires multiple successive
+      stages or involves tasks that are dependent/coupled.'
+    notes:
+    - If no multitasking was involved, leave this field blank.
+    - This characterization of `multitasking_type` is rudimentary and will likely evolve in the future.
+  - categories:
+    - Task
+    name: task_index
+    type: index
+    requirement: optional
+    description: when `multitask_type` is not empty, `task_index` refers to each of the individual tasks.
+      For example, for auditoy-visual dual N-back, `task_index=1` is the auditory task and `task_index=2`
+      is the visual task.
+    range: 1-based index.
+  - categories:
+    - Task
+    name: job_type
+    type: string
+    requirement: optional
+    description: The general type of operation the subject needs to perform. The job typically is expressed
+      as a verb (e.g., "recall", "sort") and can be the same for different instruments (e.g., Digit Span
+      test and Spatial Span test both have a job of type "recall-forward").
+  - categories:
+    - Task
+    name: job_description
+    type: string
+    requirement: optional
+    description: The more specific description of a job, which gives more information about what the participant
+      sees and has to do. Whereas the `job_type` typically uses only verbs and adjectives, the `job_description`
+      also contains nouns (e.g., “recall-digits-forward”, “recall-letters-backward”).
+  - categories:
+    - Task
+    name: job_repeat
+    type: enum
+    requirement: optional
+    description: Whether this trial's job has not been seen before in this timeline (i.e., specific version
+      of the instrument).
+    range: '- `new`: The job has never been seen before by this subject in the current study. - `repeat`:
+      The job is the same as the previous trial. - `switch`: The job is different from the previous trial
+      but has been seen prior in the timeline.'
+  - categories:
+    - Task
+    name: block_index
+    type: index
+    requirement: required
+    description: Refers to the order in which this block has been experienced by the subject. When there
+      are multiple blocks, this variable indicates the order of each block (i.e., the first block completed
+      by the subject has `block_index=1`, the second block has `block_index=2`, even if the second block
+      is an exact repetition of the first one).
+    range: 1-based index of the block within the timeline
+    notes:
+    - In questionnaires, `block_index` may refer to distinct pages where each page may contain multiple
+      questions.
+  - categories:
+    - Task
+    name: block_name
+    type: string
+    requirement: optional
+    description: The name of a particular block in a timeline. If the same block is completed twice in
+      a row, they would have different `block_index` values (1 and 2, respectively) but they would have
+      the same `block_name` (e.g., “NB_timeline1_block1”). More details about the `block_name` is available
+      in the `Instrument` table.
+  - categories:
+    - Task
+    name: block_type
+    type: enum
+    requirement: required
+    description: Specifies the experimental role of the block (e.g., tutorial, practice, test, instruction).
+    range: '- `tutorial`: A simplified version of the test designed to teach participants how the test
+      works. - `practice`: Typically identical to the main test blocks but are used to get subjects accustomed
+      to the task in a no-stakes environment. - `test`: Primary blocks used to measure the desired behaviors.
+      - `instruction`: Presents written and/or visual instructions to the subject.'
+  - categories:
+    - Task
+    name: transformation_name
+    type: string
+    requirement: required
+    description: Refers to the specific events-to-trials function used to construct rows of this table
+      from raw events. The transformation (or projection in DDD terminology) embodies the definition of
+      a trial for a particular task. The transformer name refers to a code in the format of a function
+      `f(trial_state, event) => trial_state`, where `event` is the event occurred during the performance
+      of the task, and `trial_state` is the data stored for the trial. The final state of a trial is thus
+      the result of applying a sequence of projections such that `trial = f(f(f(initial()), e), e), e)`.'
+    notes:
+    - '- The transformation/projection encapsulates the domain rules that define a "trial" for a given
+      task. It defines what constitutes a "trial".'
+  - categories:
+    - Task
+    name: trial_index
+    type: id
+    requirement: required
+    description: Sequential identifier representing number of times transformation rule to the events
+      occurred. It increases with each re-computation of the trial based on updated or newly received
+      events.
+    range: Preferably 1-based integer index.
+    notes:
+    - This field emphasizes order of trials and alignment with projection-based definition of trials.
+      A more complete name would be `projection_index` or `pojected_trial_index`. For brevity, BDM uses
+      `trial_id` instead.
+  - categories:
+    - Task
+    name: episode_index
+    type: index
+    requirement: optional
+    description: Episodes are temporally distinct bins of time (no overlap and discrete). The binning
+      of the time into successive episodes depends on the task; it is mostly used and necessary to group
+      data in cases where two distinct trials occurred at the same time (e.g., dual N-back).
+    range: 1-based interger index.
+  - categories:
+    - Task
+    name: trial_start_datetime
+    type: datetime
+    requirement: required
+    description: The the first event of the trial occured.
+  - categories:
+    - Task
+    name: trial_seed
+    type: integer | string
+    requirement: optional
+    description: Random seed used in the trial (if any).
+  - categories:
+    - Stimulus
+    name: stimulus_index
+    type: list[index]
+    requirement: optional
+    description: Indexes in chronological (or spatial) order the stimuli shown within an instrument (counting
+      one stimulus per response). `stimulus_index` may for instance be used to refer to the nth question
+      asked within a questionnaire.
+    notes:
+    - Use semicolon-separated indices if more then one stimulus were presented, e.g., `1;2;3`.
+  - categories:
+    - Stimulus
+    name: stimulus_id
+    type: integer
+    requirement: required
+    description: Is a unique identifier for the (unitary, set or sequence of) stimuli presented during
+      a trial; if those exact same stimuli are repeated in a different trial, that trial would have the
+      same value for stimulus_id. stimulus_id may also be used to refer to a specific message or question
+      in a questionnaire.
+  - categories:
+    - Stimulus
+    name: stimulus_type
+    type: enum
+    requirement: required
+    description: 'BDM distinguishes the following stimulus types: messages and questions'
+    range: '- `message`: The stimulus is a message shown to subjects (e.g., task instructions). - `question`:
+      The stimulus may consist of text, images and/or sounds; they require subjects to make a decision
+      based on the content of the stimulus.'
+  - categories:
+    - Stimulus
+    name: stimulus_onset
+    type: float
+    requirement: optional
+    description: Duration between the start of the trial and the appearance of the stimulus, in seconds.
+    range: In seconds
+  - categories:
+    - Stimulus
+    name: stimulus_panel_count
+    type: integer
+    requirement: optional
+    description: The number of panels or screen areas stimuli may appear on during the trial. For example,
+      in a task where stimuli to be compared are presented on the left and right side of the screen, stimulus_panel_count
+      = 2.
+  - categories:
+    - Stimulus
+    name: stimulus_structure
+    type: enum
+    requirement: optional
+    description: 'We distinguish three stimulus structures: unitary, set, sequence'
+    range: '- `unitary`: Only one stimulus is shown, alone. - `set`: Many stimuli are shown, either at
+      the same time or not; order does not matter. - `sequence`: Multiple stimuli are shown, either at
+      the same time or not; order does matter (order may be indicated by the order of presentation or
+      by a digit for example).'
+  - categories:
+    - Stimulus
+    name: stimulus_structure_source_type
+    type: enum
+    requirement: optional
+    description: 'Indicates the type of method used to generate the stimulus_structure (this is relevant
+      when a trial displays a sequence of or set of stimuli): none, preset, generator'
+    range: '- `none`: when stimulus_structure == unitary.", - `preset`: The structure of stimuli is hard
+      coded in a file. - `generator`: A procedure was used to generate the stimulus_structure.'
+  - categories:
+    - Stimulus
+    name: stimulus_structure_source
+    type: string
+    requirement: optional
+    description: Refers to the specific generator used to produce the stimulus_structure (e.g., sequence
+      of digits in a digit span test). When no generator was used, this variable has a value of none.
+  - categories:
+    - Stimulus
+    name: stimulus_set_size
+    type: integer
+    requirement: optional
+    description: The number of different values each presented stimulus could have taken. This value gives
+      an indication of the complexity of the stimulus space. When this number is large we set this variable
+      to infinity, when for any reason it was not computed, it has a value of NA.
+    notes:
+    - To specify "infinity" in a CSV file we use +Inf and -Inf; these are correctly recognized in R (tidyverse)
+      and Python (pandas) as being valid numbers rather than strings.
+  - categories:
+    - Stimulus
+    name: stimulus_count
+    type: integer
+    requirement: optional
+    description: The number of stimuli shown to the participant during the trial.
+    range: This should match number of stimuli in stimulus_id
+  - categories:
+    - Stimulus
+    name: stimulus_source_type
+    type: enum
+    requirement: optional
+    description: A stimulus is typically created using a particular procedure/algorithm ("generator")
+      or is sampled from a particular set ("set"). This variable indicates which of these two applies
+      for the current stimulus.
+    range: '- "set":"stimulus is sampled from a fixed set of stimuli." - "generator": "stimulus is created
+      using a procedure/algorithm."'
+  - categories:
+    - Stimulus
+    name: stimulus_source
+    type: string
+    requirement: optional
+    description: Refers to the specific generator or set the stimulus belongs to. Stimuli that stem from
+      the same source have the same data scheme and could thus be described in a table named after stimulus_source
+      (i.e., stimulus_source indicates which table contains the full information about the stimulus; e.g.,
+      "digit1to9").
+  - categories:
+    - Stimulus
+    name: stimulus_index_in_source
+    type: integer
+    requirement: optional
+    description: 'Index of the stimulus within the table referred to by stimulus_source. : For example,
+      if stimulus_source == "digit1to9", stimulus_index_in_source = 1 refers to "1" while for stimulus_source
+      == "LettersAtoD", stimulus_index_in_source = 1 refers to "A".'
+    notes:
+    - It is not because a particular stimulus_source is used in a given timeline that all possible stimuli
+      of that source are displayed to the user. For example, the AX-CPT may use "upper-case-letters" but
+      only use a subset of those letters (e.g., "A", "B", "X", "Y"). Whenever possible, we specify the
+      most relevant/specific set (e.g., "digit1to9" rather than "digit").
+  - categories:
+    - Stimulus
+    name: stimulus_position_index
+    type: integer
+    requirement: optional
+    description: Refers to discrete positions on the screen the stimulus may appear on. The set and ordering
+      of possible positions depends on the test. Whenever possible, it follows a natural order (left to
+      right, top to bottom), but in free-form layouts, indices are arbitrary.
+  - categories:
+    - Stimulus
+    name: stimulus_description
+    type: string
+    requirement: optional
+    description: A human readable, compact description of the main aspects of the stimulus. The description
+      for a given stimulus depends on the task but follows a specific template for a given task. Because
+      of this, it looks like the stimulus_description could be "parsed" and "tidied"---however, this is
+      not the intention; parsed/tidied data will be available in other tables; description is for human
+      readability and facilitates the understanding of the data.
+    notes:
+    - In some cases, when stimuli are too complex or can't be precisely described, a summary of all stimuli
+      is given instead.
+  - categories:
+    - Stimulus
+    name: stimulus_role
+    type: enum
+    requirement: optional
+    description: 'A stimulus may play different roles within a trial. Below is a list of some possible
+      roles:'
+    range: '- "target": "A stimulus the subject must process and which should trigger the completion of
+      the response (e.g., classify, reach, memorize) if the subject is doing the task as intended. Note
+      that in some cases (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click
+      the button. In this case, the stimulus that triggered the decision to NOT click the button is still
+      a *target*." - "non_target": "A stimulus the subject must process but which does not trigger the
+      completion of the response (e.g., the first two stimuli in a 2-back test)." - "distractor": "A stimulus
+      the subject should not process at all (i.e., ignore) and which is unrelated to the correct execution
+      of the task." - "location_cue": "A stimulus giving a spatial location information that subjects
+      could use to improve their performance." - "job_specifier": "A stimulus specifying which job the
+      subject should perform." - "stop_signal": "A stimulus signaling the participant he should abort
+      his current action." - "probe": "A stimulus indicating about which stimulus to respond."'
+  - categories:
+    - Option
+    name: option_source_type
+    type: enum
+    requirement: optional
+    description: A set of options is typically created using a particular procedure/algorithm (“generator”)
+      or is sampled from a particular set (“set”). This variable indicates which of these two applies
+      for the current options.
+  - categories:
+    - Option
+    name: option_source
+    type: string
+    requirement: optional
+    description: Refers to the specific generator or set that determined the options on a given trial.
+      Option that stem from the same source have the same data scheme and could thus be described in a
+      table named after option_source (i.e., option_source indicates which table contains the full information
+      about the option set).
+    notes:
+    - While there is a stimulus_index_in_source to refer to the particular stimulus that was used, we
+      don’t have an equivalent opiton_index_in_source since all options are displayed. Instead, we use
+      response_index and expected_response_index to refer to a particular option within the set of options.
+  - categories:
+    - Option
+    name: option_count
+    type: integer
+    requirement: optional
+    description: The number of options the participant can choose from on a given trial.
+  - categories:
+    - Option
+    name: option_id
+    type: integer
+    requirement: optional
+    description: Is a unique identifier for the option (set or generator) used on a given trial.
+  - categories:
+    - Option
+    name: option_data_type
+    type: enum
+    requirement: optional
+    description: 'Describes the type of data this option entails. Possible values include:'
+    range: '- "nominal": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - "ordinal":
+      "Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - "interval": Ordered
+      values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - "ratio":
+      Values with clear distance metrics and absolute zero (e.g., length in cm).'
+  - categories:
+    - Option
+    name: measurement_type
+    type: enum
+    requirement: optional
+    description: 'Describes the type of measurement implied by Option which in turn has implications on
+      how that data should be processed during analysis; takes a value in:'
+    range: '- "nominal": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - "ordinal":
+      "Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - "interval": Ordered
+      values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - "ratio":
+      Values with clear distance metrics and absolute zero (e.g., length in cm).'
+  - categories:
+    - Input
+    name: input_interface_type
+    type: enum
+    requirement: optional
+    description: 'Refers to the type of interface subjects used to input actions. Possible values include
+      (non-exhaustive):'
+    range: '- `keyboard`: A keyboard is displayed on the screen. - `buttons`: Dedicated buttons on the
+      screen. - `stimulus-button`: Stimuli serves as buttons. - `text-field`: A text field is displayed
+      on the screen. - `slider`: A slider is displayed on the screen.'
+  - categories:
+    - Input
+    name: input_action_type
+    type: enum
+    requirement: optional
+    description: 'Refers to the type of action the subject performs to give a response. Possible values
+      include (non-exhaustive):'
+    range: '- "mouse-click" - "mouse-release" - "key-press" - "key-release" - "mouse-drag" - "touch" -
+      "swipe"'
+    notes:
+    - The type of input_action determines the structure of detailed response data (i.e., mouse-click data
+      is different from key-press data).
+  - categories:
+    - Input
+    name: input_count
+    type: integer
+    requirement: optional
+    description: The number of inputs (i.e., actions) the user made during the trial.
+    notes:
+    - For mouse-drag, it corresponds to the number of drag points that have been sampled during the drag-and-drop.
+  - categories:
+    - Expectation
+    name: expected_response_option_index
+    type: integer
+    requirement: optional
+    description: The index of the option the subject is expected to choose from the set of options.
+    notes:
+    - When expected_response_index = 0, it means that the subject should not respond at all.
+    - Sometimes stimuli serve both as stimuli and as response options as subjects have to click on a particular
+      stimuli to give their response (e.g., spatial span, odd one out). It is convenient in those cases
+      to use stimulus_position_index to order/index the options (i.e., option_index == stimulus_position_index)
+      and consequently also the responses.
+  - categories:
+    - Expectation
+    name: expected_response_description
+    type: string
+    requirement: optional
+    description: A description of the expected response using the same convention as response_description.
+  - categories:
+    - Response
+    name: response_structure
+    type: string
+    requirement: optional
+    description: 'The structure of the response required by the subject; can take values in:'
+    range: '- `unitary`: The subject provides a single input (e.g., chooses option *same*). - `set`: The
+      subject provides a set of information, and the order does not matter (e.g., list words that start
+      with the letter *A*). - `sequence`: The subject provides a sequence of information, and the order
+      matters (e.g., a sequence of memorized digits in their order of appearance).'
+    notes:
+    - Note that the distinction between set and sequence refers to the importance of order information
+      to evaluate if the response is correct or not; a response with a set structure may unfold over time
+      (each piece of information is given in a particular temporal order) and it may be of scientific
+      interest to take into account that order; however, the order itself is not important within the
+      task itself. For example, in the [MOT task](https://en.wikipedia.org/wiki/Multiple_object_tracking)
+      one may ask subjects to point to all dots that hide a token. If subjects point to all such dots
+      they will be correct no matter in which order the dots were clicked in.
+  - categories:
+    - Response
+    name: response_count
+    type: integer
+    requirement: optional
+    description: Each trial contains by definition only one response. However, when response_structure
+      is other than unitary, a response comprises multiple pieces of information (e.g., “3-5-7” could
+      be one response in the digit span task and this response contains three components, namely “3”,
+      “5” and “7”). response_count refers to the number of components that make up a response (not the
+      number of responses within a trial).
+    notes:
+    - response_count is different from input_count; a subject may in some cases change their response
+      multiple times before submitting the final response. In such cases, there would be many more inputs
+      than there are components to the final response.
+    - While we have stimulus_set_size we currently don’t have a response_set_size, but we do have option_count
+      and response_count.
+  - categories:
+    - Response
+    name: response_option_index
+    type: integer
+    requirement: optional
+    description: The index of the option the participant chose, starting from 1.
+    notes:
+    - response_option_index = 0 means the subject chose none of the options (e.g., a “no-go” response
+      in a Go/No-go task).
+    - response_index can be directly compared to expected_response_index.
+    - response_index refers to an entry in the Option table (i.e., there is no Response table).
+  - categories:
+    - Response
+    name: response_description
+    type: string
+    requirement: optional
+    description: A description of participant’s response; typically the description of the option that
+      was chosen.
+    notes:
+    - response_description can be directly compared to expected_response_description.
+  - categories:
+    - Response
+    name: response_numeric
+    type: float
+    requirement: optional
+    description: A numeric value associated with a particular response; this could be a numeric value
+      entered directly by the subject or the numeric meaning of a selected option (for example, the choice
+      of option "Never" may be associated with the numeric value of 0). Note that this variable describes
+      the subject's response; it does not describe the value (e.g., correctness or goodness) that is associated
+      with that response.
+  - categories:
+    - Response
+    name: response_time
+    type: float
+    requirement: optional
+    description: The duration, in seconds, between the earliest possible time a response could have been
+      completed and the moment that response was actually completed (and NOT when it was initiated).
+  - categories:
+    - Response
+    name: response_datetime
+    type: datetime
+    requirement: optional
+    description: The datetime corresponding to the completion of the response.
+  - categories:
+    - Response
+    name: response_validation_time
+    type: float
+    requirement: optional
+    description: In some cases, subjects may need to press an extra key to validate previous responses.
+      When relevant, this variable may encode this duration.
+  - categories:
+    - Response
+    name: response_initiation_time
+    type: float
+    requirement: optional
+    description: In some cases (e.g., a reaching movement) it might be useful to encode when a response
+      was initiated.
+  - categories:
+    - Response
+    name: response_skipped
+    type: boolean
+    requirement: optional
+    description: In some cases (e.g., in some questionnaires), subjects have the option to skip a question.
+  - categories:
+    - Response
+    name: timed_out
+    type: boolean
+    requirement: optional
+    description: Some tasks require subjects to give a response within a certain time limit. When subjects
+      fail to respond before that time runs out, timed_out is set to TRUE.
+  - categories:
+    - Evaluation
+    name: accuracy
+    type: float
+    requirement: optional
+    description: A task-dependent accuracy measure ranging from 0 to 1 (inclusive).
+  - categories:
+    - Evaluation
+    name: correct
+    type: boolean
+    requirement: optional
+    description: Indicates whether the response matches the expected response (i.e., correct = TRUE) or
+      not (i.e., correct = FALSE).
+  - categories:
+    - Evaluation
+    name: score
+    type: float
+    requirement: optional
+    description: A numeric value associated with a particular response in a given context. This variable
+      may be used to compute a performance metric or a questionnaire level index (e.g., a well-being score).
+  - categories:
+    - Evaluation
+    name: evaluation_label
+    type: enum
+    requirement: optional
+    description: 'There are several labels that can be assigned to a given response to specify what that
+      response means in terms of evaluation within a task. The most general terms are "correct” and "error"
+      (which are already given by the correct variable). There are however more specific sets of terms
+      that may apply in different contexts. For example, in a signal detection task, it is common to use
+      labels from the signal detection theory framework (i.e., “hit”, “miss”, “false alarm”, “correct
+      rejection”). In other contexts, researchers might use terms like “omission” or “commission” errors
+      or even things like “perseveration” error (e.g., in the Wisconsin Card Sorting Test). Note that
+      these terms are not always well defined or exclusive. For example, a “hit” is also a “correct” response
+      and a “false alarm” may be synonymous to “commission error”. Whenever possible use the more specific
+      terms (i.e., always use “hit” rather than “correct” when applicable). Here are few evaluation labels
+      that are commonly used:'
+    range: '- `correct`: The response is correct. - `error`: The response is incorrect. - `hit`: The stimulus
+      was *present* and the subject correctly responded *present*. - `miss`: The stimulus was *present*
+      and the subject correctly responded *absent*. - `fa`: The stimulus was *absent* and the subject
+      correctly responded *present*. - `cr`: The stimulus was *absent* and the subject correctly responded
+      *absent*.'
+  - categories:
+    - Feedback
+    name: feedback_description
+    type: string
+    requirement: optional
+    description: 'Lists the different kinds of feedback that were shown on a given trial. When multiple
+      types of feedback were used, feedback will list them using `;` as a separator. If a given type of
+      feedback was shown multiple times during a trial, that feedback type is listed only once (i.e.,
+      feedback_description does NOT represent the sequence of feedbacks). The possible values for feedback
+      are:'
+    range: '- `none`: No feedback was shown. - `expected_response`: Feedback indicated what the correct
+      response would have been. - `explanation`: Feedback explains *why* a certain option is the correct
+      one. - `correctness_on_option`: "Feedback indicates (on the option itself) if the option chosen
+      by the participant was the correct one (e.g., in green), or not (e.g., in red). - `correctness_on_screen`:
+      "Feedback displayed on the screen center indicates if the response to the current trial was correct
+      or not (e.g., using a green check or a red cross).'
+    notes:
+    - This list is not exhaustive and characterizing feedback in the future will involve more variables
+      (e.g., separating the type of information shown (e.g., correctness) and how it is shown (“on_option”
+      versus “on_screen”).
+    - 'NOTE2: We don’t consider here as “feedback”, the kind of feedback that is used in UI to confirm
+      to users that a button has indeed been clicked.'
+  - categories:
+    - Outcome
+    name: outcome_description
+    type: string
+    requirement: optional
+    description: Describes the observable consequences of the subject's response (e.g., "the opened box
+      is empty").
+  - categories:
+    - Outcome
+    name: outcome_numeric
+    type: float
+    requirement: optional
+    description: A numeric value describing the observable consequences of the subject's response (e.g.,
+      +3 points).
+  - categories:
+    - Accessory
+    name: additional_measures
+    type: string
+    requirement: optional
+    description: 'Indicates whether additional measures have been recorded during this trial and if so
+      what kind of measures they are. Possible values include (non-exhaustive):'
+    range: '- `mouse_trajectories` - `fmri` - `eye_tracking` - `heart_rate`'
+    notes:
+    - Leave this field empty if no additional measures were recorded for this specific response.
+  - categories:
+    - Experimental Design
+    name: adaptive_method_name
+    type: enum
+    requirement: optional
+    description: Specifies the adaptive procedure used to modify instrument parameters in response to
+      subject performance (e.g., `staircase`).
+  - categories:
+    - Experimental Design
+    name: adaptive_method_config
+    type: string
+    requirement: optional
+    description: More detailed configuration for the adaptive method, including initial values, step sizes,
+      and termination criteria.
+    notes:
+    - For example, `1up-2down`. The 1-up, 2-down is a common adaptive staircase procedure used to estimate
+      a subject's threshold or sensitivity. After a correct response, the difficulty level is increased,
+      and after two incorrect responses, the difficulty level is decreased.
+  - categories:
+    - Experimental Design
+    name: adaptive_parameter_name
+    type: string
+    requirement: optional
+    description: Specific instrument parameter that is dynamically modified based on the subject's performance.
+  - categories:
+    - Experimental Design
+    name: adaptive_parameter_value
+    type: any
+    requirement: optional
+    description: The specific value of the instrument parameter that was used for this trial. This value
+      is updated as the adaptive algorithm adjusts the parameter based on the subject's responses.
+    range: Data type depends on the type of the adaptive parameter, as defined in `adaptive_parameter_name`)
+  - categories:
+    - Experimental Design
+    name: adaptive_parameter_value_next
+    type: any
+    requirement: optional
+    description: The next value of the adaptive parameter that will be used in the subsequent trial, as
+      determined by the adaptive algorithm.
+    range: Data type depends on the type of the adaptive parameter, as defined in `adaptive_parameter_name`)
+- name: Stimulus
+  label: Stimulus
+  description: Describes each of the stimuli that were shown during an trial.
+  notes:
+  - Each row of `Stimulus` table corresponds to a stimulus in a trial. Each trial can contain different
+    number of stimuli.
+  fields:
+  - categories:
+    - Key
+    name: stimulus_id
+    type: PRIMARY KEY
+    requirement: required
+    description: Primary key of the `Stimulus` table. Reference to this identifier in other tables are
+      thus named `stimulus_id`.
+    range: Each row in this table has a unique `id`.
+    notes:
+    - If the same stimulus is shown at two different times in a trial, those two instances will have their
+      own row in the `Stimulus` table, each with its own `id`.
+    - Make sure to refer to this field as `stimulus_id` rather than `id` When joining tables. This also
+      applies to all the `id` fields; they are named `id` within their own context/table, but `<context/table>_id`
+      when addressed from other tables. For example, `X_id` in a table refers (hence a foreign key) to
+      the `id` column in the X table.
+  - categories:
+    - Context
+    name: trial_id
+    type: id
+    requirement: optional
+    description: Refers to the `trial_index` in the `Response` table and indicates in which trial this
+      stimulus was shown.
+    range: '`trial_id` in the `Response` table of the same agent/session/activity/attempt'
+  - categories:
+    - Context
+    name: response_id
+    type: id
+    requirement: required
+    description: Refers to the `response_id` in the `Response` table and indicates for which response
+      this stimulus was shown.
+    range: '`response_id` in the `Response` table of the same agent/session/activity/attempt'
+  - categories:
+    - Context
+    name: object_id
+    type: string
+    requirement: optional
+    description: A stimulus is defined by a set of features. This variable is used to identify each time
+      the same stimulus features were used.
+    notes:
+    - For example, if the same white digit "3" is shown in a digit span sequence, all those instances
+      would have the same `object_id` although they would have different `id`s (as they appeared at different
+      times).
+  - categories:
+    - Context
+    name: presentation_id
+    type: string
+    requirement: optional
+    description: In a multitasking setting, a particular instance of a stimulus (e.g., the current letter
+      "A") may be used by multiple tasks at the same time (e.g, in the dual N-back task). Because these
+      are different trials, they will have different `trial_id` values and hence will have different rows
+      in the `Stimulus` table. We use `presentation_id` to indicate that a given stimulus is in fact the
+      same instance across those trials.
+  - categories:
+    - Context
+    name: index_in_trial
+    type: integer
+    requirement: optional
+    description: Refers to individual stimuli within the sequence or set of stimuli shown during a trial.
+  - categories:
+    - When
+    name: onset
+    type: float
+    requirement: required
+    description: Duration between the start of the trial and the appearance of the stimulus, in seconds.
+    range: In seconds
+  - categories:
+    - When
+    name: duration
+    type: float
+    requirement: required
+    description: Describes for how long this stimulus was displayed after its onset, in seconds.
+    range: In seconds
+    notes:
+    - When the stimulus is shown using an animation, `duration` covers the complete period between the
+      start of the animation and the end of the animation.
+  - categories:
+    - Where
+    name: panel_id
+    type: string
+    requirement: optional
+    description: Identifier of the panel this stimulus is displayed over.
+  - categories:
+    - Where
+    name: x_screen
+    type: integer
+    requirement: optional
+    description: X coordinates of the stimulus on the screen in pixels.
+    notes:
+    - In BDM, the preferred position is the center of the object. However, specific implementations of
+      the tasks may use other locations such as the top-left corner. If this is the case, it should be
+      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+  - categories:
+    - Where
+    name: y_screen
+    type: integer
+    requirement: optional
+    description: Y coordinates of the stimulus on the screen in pixels.
+  - categories:
+    - Where
+    name: x_viewport
+    type: float
+    requirement: optional
+    description: X coordinates of the stimulus on the screen expressed as a fraction of the screen width.
+    range: 0 to 1 (inclusive)
+  - categories:
+    - Where
+    name: y_viewport
+    type: float
+    requirement: optional
+    description: Y coordinates of the stimulus on the screen expressed as a fraction of the screen height.
+    range: 0 to 1 (inclusive)
+  - categories:
+    - What
+    name: description
+    type: string
+    requirement: required
+    description: A human readable, compact description of the main aspects of the stimulus. The description
+      for a given stimulus depends on the task but follows a specific template for a given task. Because
+      of this, it looks like the `description` could be parsed and converted into a more structured format---however,
+      this is not the intention; structured data will be available in other tables; here, description
+      is for human readability and facilitates the understanding of the data.
+  - categories:
+    - What
+    name: source
+    type: string
+    requirement: required
+    description: Refers to the specific generator or set the stimulus belongs to.
+    notes:
+    - Stimuli that come from the same source have the same data scheme and could thus be described in
+      a table named after the `stimulus_source`. `stimulus_source` indicates which table contains the
+      full information about the stimulus; e.g., "digits1to9".
+    - One could include a `source_count` variable here that indicates how many different stimuli there
+      are in the set; but it's better stored in the table that contains information about that stimulus
+      source.
+  - categories:
+    - What
+    name: source_type
+    type: enum
+    requirement: optional
+    description: A stimulus is typically created using a particular procedure/algorithm ("generator")
+      or is sampled from a particular set ("set"). This variable indicates which of these two applies
+      for the current stimulus.
+    range: '- `set`: stimulus is sampled from a fixed set of stimuli. - `generator`: "stimulus is created
+      using a procedure/algorithm.'
+  - categories:
+    - What
+    name: index_in_source
+    type: integer
+    requirement: optional
+    description: When a stimulus is picked from a particular set (e.g., "digits1to9"), this index refers
+      to the index within that set.
+    notes:
+    - In addition to `index_in_source`, `stimulus_id` can also be used to look up further information
+      about the stimulus in the source.
+  - categories:
+    - What
+    name: role
+    type: enum
+    requirement: required
+    description: Describe the role that the stimulus plays in the trial, e.g., "target".
+    range: '- `target`: A stimulus the agent must process and which should trigger the completion of the
+      response (e.g., classify, reach, memorize) if the agent is doing the task as intended. In some cases
+      (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click the button. In this
+      case, the stimulus that triggered the decision to NOT click the button is still a `target`. - `non_target`:
+      A stimulus the agent must process but which does not trigger the completion of the response (e.g.,
+      the first two stimuli in a 2-back test). - `distractor`: "A stimulus the agent should not process
+      at all (i.e., ignore) and which is unrelated to the correct execution of the task. - `location_cue`:
+      A stimulus giving a spatial location information that agents could use to improve their performance.
+      - `job_specifier`: A stimulus specifying which job the agent should perform. - `stop_signal`: "A
+      stimulus signaling the agents that they should abort current action. - `probe`: A stimulus indicating
+      about which stimulus to respond.'
+  - categories:
+    - How
+    name: animation
+    type: string
+    requirement: optional
+    description: Describes the animation used to display a specific stimulus in a human-readable format.
+      For example, "fadeIn 3s" indicates a 3-second fade-in animation.
+    notes:
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common
+      animations (e.g., "3s linear slide-in").
+- name: Option
+  label: Option
+  description: Describes each option that a subject could choose from in a trial.
+  notes:
+  - Note that in some tasks, the options may change within a trial after each input (e.g., serial self-ordered
+    search task); therefore the options are optionally indexed by `input_index`.
+  fields:
+  - categories:
+    - Key
+    name: option_id
+    type: PRIMARY KEY
+    requirement: required
+    description: Primary key of the `Option` table. Reference to this identifier in other tables are thus
+      named `option_id`.
+    range: Each row in this table has a unique `id`
+    notes:
+    - If the same option is shown at two different times in a trial, those two instances will have their
+      own row in the * Option* table, each with its own `id`.
+  - categories:
+    - Context
+    name: trial_index
+    type: id
+    requirement: required
+    description: Refers to the `trial_index` in the `Response` table and indicates in which trial this
+      option was shown.
+    range: '`trial_index` in the `Response` table for the same subject/session/activity'
+  - categories:
+    - Context
+    name: response_id
+    type: id
+    requirement: optional
+    description: Refers to the `response_id` in the `Response` table and indicates for which response
+      this option was shown.
+    range: '`response_id` in the `Response` table of the same subject/activity'
+  - categories:
+    - Context
+    name: index_in_trial
+    type: index
+    requirement: optional
+    description: Indexing each of the options within the set of options that were available to subjects
+      on a given trial.
+    range: 1-based indices
+    notes:
+    - If the presented options have no specific temporal or spatial order, leave this field empty or assign
+      the same index to all options, e.g., `index_in_trial=1`.
+  - categories:
+    - Context
+    name: object_id
+    type: string
+    requirement: optional
+    description: An option is defined by a set of features. This variable is used to identify each time
+      the same features were used. For example, if the same white digit "3" is used as an option in the
+      Digit Span task, all those instances would have the same `object_id` although they would have different
+      `id`s (as they appeared at different times).
+  - categories:
+    - When
+    name: onset
+    type: float
+    requirement: required
+    description: Duration between the start of the trial and the moment the option was displayed or activated,
+      in seconds.
+    range: In seconds
+  - categories:
+    - When
+    name: duration
+    type: float
+    requirement: required
+    description: How long the option was displayed or active in seconds, starting from the `onset`, in
+      seconds.
+    range: In seconds
+  - categories:
+    - Where
+    name: panel_id
+    type: string
+    requirement: optional
+    description: Identifier of the pane this option was displayed over.
+  - categories:
+    - Where
+    name: x_screen
+    type: float
+    requirement: optional
+    description: X coordinates of the option component on the screen in pixels.
+    notes:
+    - In BDM, the preferred position is the center of the object. However, specific implementations of
+      the tasks may use other locations such as the top-left corner. If this is the case, it should be
+      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+  - categories:
+    - Where
+    name: y_screen
+    type: float
+    requirement: optional
+    description: Y coordinates of the option component on the screen in pixels.
+  - categories:
+    - Where
+    name: x_viewport
+    type: float
+    requirement: optional
+    description: X coordinates of the option component on the screen expressed as a fraction of the screen
+      width.
+    range: 0 to 1 (inclusive).
+  - categories:
+    - Where
+    name: y_viewport
+    type: float
+    requirement: optional
+    description: Y coordinates of the option component on the screen expressed as a fraction of the screen
+      height.
+    range: 0 to 1 (inclusive).
+  - categories:
+    - What
+    name: description
+    type: string
+    requirement: required
+    description: A human readable, compact description of the main aspects of the option. The description
+      for a given option depends on the task but follows a specific template for a given task. Because
+      of this, it looks like the option description could be parsed---however, this is not the intention;
+      structured, parsed data will be available in other fields; description is for human readability
+      and facilitates the understanding of the data.
+  - categories:
+    - What
+    name: value
+    type: float
+    requirement: optional
+    description: A numeric value associated with a particular response option; typically indicating the
+      "worth" of a response (e.g., `value=1` for the correct response).
+  - categories:
+    - What
+    name: source
+    type: string
+    requirement: required
+    description: Refers to the specific generator or set from which the option originates. Options sharing
+      the same source have the same data structure and can be thus collectively described in a table named
+      after `option_source` (e.g., "digit1to9").
+    notes:
+    - The `option_source` specifies the table or file that provides complete details about the option.
+      For instance, `option_source=digit1to9` indicates a source containing information on digits 1 to
+      9.
+  - categories:
+    - What
+    name: source_type
+    type: enum
+    requirement: optional
+    description: An option is typically created using a particular procedure/algorithm or is sampled from
+      a particular set. This variable indicates which of these two applies for the current option.
+    range: '- `set`: option is sampled from a fixed set of options. - `generator`: option is created using
+      a procedure/algorithm.'
+  - categories:
+    - What
+    name: index_in_source
+    type: integer
+    requirement: optional
+    description: When a option is picked from a particular set (e.g., `digits1to9`), this index refers
+      to the index within that set.
+  - categories:
+    - How
+    name: animation
+    type: string
+    requirement: optional
+    description: Describes the animation used to display a specific option in a human-readable format.
+      For example, "fadeIn 3s ease-in-out" indicates a 3-second fade-in animation.
+    notes:
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common
+      animations (e.g., "3s linear slide-in").
+- name: Input
+  label: Input
+  description: A detailed log of all inputs and clicks recorded during the trial.
+  fields:
+  - categories:
+    - Key
+    name: input_id
+    type: PRIMARY KEY
+    requirement: required
+    description: Primary key; each input or click has its own identifier value that is unique within the
+      table.
+  - categories:
+    - Context
+    name: response_id
+    type: id
+    requirement: required
+    description: Indexing all the clicks that occurred within a given trial; ranging from 1 to `input_count`
+      in the corresponding `Response` table.
+  - categories:
+    - Context
+    name: response_element_index
+    type: index
+    requirement: optional
+    description: Indicates which of the clicks is used and in what order to form the actual response in
+      the response table when `response_structure` is "sequence" or "set".
+    range: 1 to `input_count` in the corresponding row of the `Response` table.
+    notes:
+    - This needs to be here rather than in `Option` table, because the same option can be clicked multiple
+      times and either serve or not for the response depending on the order of the clicks. For example,
+      in the Digit Span test we could have the response of "3;5;7" on a particular trial. This might correspond
+      to > - `option.description` = ["3", "4", "delete", "delete", "3", "5", "7", "enter"] > - `click.response_element_index`
+      = [NA, NA, NA, NA, 1, 2, 3, NA]
+  - categories:
+    - When
+    name: onset
+    type: float
+    requirement: required
+    description: Duration between the start of the trial and the moment the mouse button press occured,
+      in seconds.
+    range: seconds
+  - categories:
+    - When
+    name: duration
+    type: float
+    requirement: optional
+    description: Describes for how long the mouse button was pressed, in seconds.
+    range: seconds
+  - categories:
+    - Where
+    name: x_screen
+    type: integer
+    requirement: optional
+    description: X coordinates of the click relative to the left edge of the screen in pixels.
+    range: pixels
+  - categories:
+    - Where
+    name: y_screen
+    type: integer
+    requirement: optional
+    description: Y coordinates of the click relative to the top edge of the screen in pixels.
+    range: pixels
+  - categories:
+    - Where
+    name: x_viewport
+    type: float
+    requirement: optional
+    description: X coordinates of the click relative to the left edge of the screen expressed as a fraction
+      of the screen width.
+    range: 0 to 1 (inclusive).
+  - categories:
+    - Where
+    name: y_viewport
+    type: float
+    requirement: optional
+    description: Y coordinates of the click relative to the top edge of the screen expressed as a fraction
+      of the screen height.
+    range: 0 to 1 (inclusive).
+  - categories:
+    - What
+    name: object_type
+    type: enum
+    requirement: required
+    description: Describes the type of object that was clicked on (e.g., "button").
+  - categories:
+    - What
+    name: object_name
+    type: string
+    requirement: required
+    description: The human-readable name of the object that was clicked on (e.g., "sos_box_1_3").
+  - categories:
+    - What
+    name: is_object_enabled
+    type: boolean
+    requirement: optional
+    description: Indicates whether the object that was clicked on was enabled (clickable) or not.
+  - categories:
+    - What
+    name: object_state
+    type: string
+    requirement: optional
+    description: Describes the state the object was in *before* it was clicked on. The meaning of "state"
+      depends on the particular task (e.g., "new empty").
+  - categories:
+    - What
+    name: option_id
+    type: id
+    requirement: optional
+    description: If the click is on an option, this variable indicates which option it was.
+    range: Corresponding `option_id` in the `Option` table.
+  - categories:
+    - What
+    name: stimulus_id
+    type: id
+    requirement: optional
+    description: If the click is on a stimulus, this variable indicates which stimulus it was.
+    range: Corresponding `stimulus_id` in the `Stimulus` table.
+- name: StimulusComponent
+  label: StimulusComponent
+  description: Stimuli can comprise multiple components. This table describes each component of a stimulus.
+  fields:
+  - categories:
+    - Key
+    name: stimulus_id
+    type: null
+    requirement: required
+    description: A reference to the primary key `id` of the `Stimulus` table.
+    range: '`stimulus_id` in the corresponding `Stimulus` table (same subject/session/activity).'
+  - categories:
+    - Key
+    name: index
+    type: index
+    requirement: required
+    description: A 1-based index indicating the stacking order of stimulus components. A stimulus component
+      with a higher `index` is displayed on top of those with lower values, similar to CSS z-index property.
+    range: 1-based indices
+    notes:
+    - If the presented options have no specific temporal or spatial order, leave this field empty or assign
+      the same index to all options, e.g., `index=1`.
+  - categories:
+    - Where
+    name: x_screen
+    type: integer
+    requirement: optional
+    description: X coordinates of the stimulus component relative to the left edge of the screen in pixels.
+    range: pixels
+    notes:
+    - In BDM, the preferred position is the center of the object. However, specific implementations of
+      the tasks may use other locations such as the top-left corner. If this is the case, it should be
+      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+  - categories:
+    - Where
+    name: y_screen
+    type: integer
+    requirement: optional
+    description: Y coordinates of the stimulus component relative to the top edge of the screen in pixels.
+    range: pixels
+  - categories:
+    - Where
+    name: x_viewport
+    type: float
+    requirement: optional
+    description: X coordinates of the stimulus component relative to the left edge of the screen expressed
+      as a fraction of the screen width.
+    range: 0 to 1 (inclusive)
+  - categories:
+    - Where
+    name: y_viewport
+    type: float
+    requirement: optional
+    description: Y coordinates of the stimulus component relative to the top edge of the screen expressed
+      as a fraction of the screen height.
+    range: 0 to 1 (inclusive)
+  - categories:
+    - What
+    name: description
+    type: string
+    requirement: required
+    description: A human readable, compact description of the component.
+  - categories:
+    - What
+    name: symbol_name
+    type: string
+    requirement: optional
+    description: The human-readable name of the displayed symbol.
+  - categories:
+    - What
+    name: symbol_count
+    type: integer
+    requirement: optional
+    description: The number of symbols represented in this component.
+  - categories:
+    - What
+    name: symbol_layout
+    type: enum
+    requirement: optional
+    description: How the symbols are laid out.
+    range: '- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` -
+      `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`'
+    notes:
+    - If none of the predefined layouts apply, leave this field empty or use a custom human-readable label.
+      Make sure custom labels are clearly defined in the codebook.
+  - categories:
+    - What
+    name: color_name
+    type: string
+    requirement: optional
+    description: The human-readable name of the component color, e.g., `red`.
+    notes:
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors
+      (e.g., "lightgray").
+  - categories:
+    - What
+    name: color_hex
+    type: string
+    requirement: optional
+    description: 'The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional
+      alpha channel for transparency.'
+    range: '#000000 to #FFFFFF'
+  - categories:
+    - What
+    name: orientation
+    type: enum
+    requirement: optional
+    description: Indicates the symbol orientation.
+    range: '- `north`: bottom to top. - `north_east` - `east`: left to right. - `south_east` - `south`:
+      top to bottom. - `south_west` - `west`: right to left - `north_west` - `free`: no specific orientation.'
+    notes:
+    - If none of the predefined orientations apply, leave this field empty or use a custom human-readable
+      label. Make sure custom labels are clearly defined in the codebook.
+- name: OptionComponent
+  label: OptionComponent
+  description: Options can comprise multiple components. This table describes each component of an option.
+  fields:
+  - categories:
+    - Key
+    name: index
+    type: index
+    requirement: required
+    description: A 1-based index differentiating each part and indicating the stacking order of them.
+      An option component with a higher `index` is displayed on top of those with lower values, similar
+      to CSS z-index property.
+    range: 1-based indices
+  - categories:
+    - Key
+    name: option_id
+    type: id
+    requirement: required
+    description: A reference to the key `option_id` in the `Option` table.
+    range: '`option_id` in the corresponding `Option` table (same subject/session/activity).'
+  - categories:
+    - Where
+    name: panel_id
+    type: string
+    requirement: optional
+    description: Identifier of the panel this option is displayed over.
+  - categories:
+    - Where
+    name: x_screen
+    type: integer
+    requirement: optional
+    description: X coordinates of the option component relative to the left edge of the screen in pixels.
+    range: pixels
+    notes:
+    - In BDM, the preferred position is the center of the object. However, specific implementations of
+      the tasks may use other locations such as the top-left corner. If this is the case, it should be
+      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+  - categories:
+    - Where
+    name: y_screen
+    type: integer
+    requirement: optional
+    description: Y coordinates of the option component relative to the top edge of the screen in pixels.
+    range: pixels
+  - categories:
+    - Where
+    name: x_viewport
+    type: float
+    requirement: optional
+    description: X coordinates of the option component relative to the left edge of the screen expressed
+      as a fraction of the screen width.
+    range: 0 to 1 (inclusive)
+  - categories:
+    - Where
+    name: y_viewport
+    type: float
+    requirement: optional
+    description: Y coordinates of the option component relative to the top edge of the screen expressed
+      as a fraction of the screen height.
+    range: 0 to 1 (inclusive)
+  - categories:
+    - What
+    name: description
+    type: string
+    requirement: required
+    description: A human readable, compact description of the component.
+  - categories:
+    - What
+    name: symbol_name
+    type: string
+    requirement: optional
+    description: The name of the displayed symbol.
+  - categories:
+    - What
+    name: symbol_count
+    type: integer
+    requirement: optional
+    description: The number of symbols represented in this component.
+  - categories:
+    - What
+    name: symbol_layout
+    type: enum
+    requirement: optional
+    description: How the symbols are laid out.
+    range: '- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` -
+      `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`'
+    notes:
+    - If none of the predefined layouts apply, leave this field empty or use a custom human-readable label.
+      Make sure custom labels are clearly defined in the codebook.
+  - categories:
+    - What
+    name: color_name
+    type: string
+    requirement: optional
+    description: The human-readable name of the component color, e.g., `red`.
+    notes:
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors
+      (e.g., "lightgray").
+  - categories:
+    - What
+    name: color_hex
+    type: string
+    requirement: optional
+    description: 'The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional
+      alpha channel for transparency.'
+    range: '#000000(00) to #FFFFFF(FF)'
+  - categories:
+    - What
+    name: orientation
+    type: enum
+    requirement: optional
+    description: Indicates the symbol orientation.
+    notes:
+    - If none of the predefined orientations apply, leave this field empty or use a custom human-readable
+      label. Make sure custom labels are clearly defined in the codebook.
+- name: Instrument
+  label: Instrument
+  description: Describes the instrument used for data acquisition.
+  notes:
+  - this table includes information about specific parameterizations of the instruments (i.e., timelines).
+    For example, parameters for the software that executes the presentation of the stimuli and records
+    key presses.
+  fields:
+  - categories:
+    - Identifier
+    name: instrument_id
+    type: string
+    requirement: required
+    description: Unique identifier of an instrument. It can be formed by combining name and version (e.g.,
+      "DS_v2024.01").
+  - categories:
+    - Identifier
+    name: timeline_id
+    type: string
+    requirement: required
+    description: Identifier for a timeline. Timeline is a variant of an instrument with specific parametrization,
+      for the whole experiment or for multiple block of trials (e.g., "DS_FORWARD" and "DS_BACKWARD" for
+      digit span task). Timelines are configurations that specify instrument parameters.
+  - categories:
+    - Identifier
+    name: block_id
+    type: string
+    requirement: required
+    description: Specific parameterization of the instrument for a single block of trials (e.g., "DS_FORWARD_PRACTICE"
+      and "DS_FOWARD_TEST"). Block-level parameters override timeline-level parameters.
+  - categories:
+    - What
+    name: name
+    type: string
+    requirement: required
+    description: Name of the toolkit (scene, code, or configuration) that is used to collect the data,
+      e.g., "DS" for a software that runs digit span task in forward OR backward order. The specific parameterization
+      of the instrument is defined by the "Timeline" (e.g., a variant of instrument called "DS_FORWARD").
+  - categories:
+    - What
+    name: version
+    type: string
+    requirement: optional
+    description: Refers to the specific version/build of a particular instrument. We will use a calendar
+      based versioning system ([calver.org](https://calver.org/); e.g., "v2024.01").
+  - categories:
+    - What
+    name: description
+    type: string
+    requirement: optional
+    description: A human readable, compact description of the main aspects of the instrument.
+  - categories:
+    - What
+    name: link
+    type: url
+    requirement: optional
+    description: External link, if any, the provides more information about the instrument, e.g., on Cognitive
+      Atlas.
+    notes:
+    - Permanent links, e.g., DOIs, are preferred over particular websites.

--- a/trial/field-definitions.yaml
+++ b/trial/field-definitions.yaml
@@ -8,29 +8,22 @@ schema_metadata:
   name: Behaverse Trial Schema
   version: '26.0608'
   namespace: https://behaverse.org/schemas/trial
-  description: Tidy tables describing trial-level behavioral data for cognitive tests and questionnaires,
-    derived from raw events.
+  description: Tidy tables describing trial-level behavioral data for cognitive tests and questionnaires, derived from raw events.
 tables:
 - name: Response
   label: Response
   description: Main table where each row describes a response in a trial.
   notes:
-  - The information in this table should be sufficient for most analyses, but more detailed information
-    may be linked from other tables via identifiers (`response_id` and `trial_index`).
+  - The information in this table should be sufficient for most analyses, but more detailed information may be linked from other tables via identifiers (`response_id` and `trial_index`).
   fields:
   - categories:
     - Key
     name: response_id
     type: PRIMARY KEY
     requirement: required
-    description: A unique identifier assigned to responses in temporal order, meaning that larger IDs
-      correspond to more recent responses that occurred later in time. This ID is unique within this table;
-      no two rows share the same value.
+    description: A unique identifier assigned to responses in temporal order, meaning that larger IDs correspond to more recent responses that occurred later in time. This ID is unique within this table; no two rows share the same value.
     notes:
-    - This identifier is used by other tables, for example `Stimulus` table which describes in greater
-      detail the sequence of images shown during a trial, their timing, and visual properties. That table
-      will refer to this `id` in order to link those descriptions (typically multiple lines in the Stimulus
-      table) to a unique row in the `Response` table.
+    - This identifier is used by other tables, for example `Stimulus` table which describes in greater detail the sequence of images shown during a trial, their timing, and visual properties. That table will refer to this `id` in order to link those descriptions (typically multiple lines in the Stimulus table) to a unique row in the `Response` table.
   - categories:
     - Context
     name: study_name
@@ -42,23 +35,19 @@ tables:
     name: group_name
     type: string
     requirement: optional
-    description: Subjects may be assigned to different groups. Typically, different groups will have different
-      experiences within a study.
+    description: Subjects may be assigned to different groups. Typically, different groups will have different experiences within a study.
   - categories:
     - Context
     name: agent_id
     type: string
     requirement: required
-    description: A unique identifier assigned to the agent (typically person) generating the responses.
-      This ID tracks their participation and responses throughout the study. See `Agent` table.
+    description: A unique identifier assigned to the agent (typically person) generating the responses. This ID tracks their participation and responses throughout the study. See `Agent` table.
   - categories:
     - Context
     name: session_id
     type: integer
     requirement: required
-    description: When there are multiple sessions, this variable indicates the order of each session (i.e.,
-      the first session completed by the subject has `session_index` = 1, the second session has `session_index`
-      = 2; even if the second session is an exact repetition of the first one.
+    description: When there are multiple sessions, this variable indicates the order of each session (i.e., the first session completed by the subject has `session_index` = 1, the second session has `session_index` = 2; even if the second session is an exact repetition of the first one.
     range: index of session within subject.
     notes:
     - We currently don’t use session_name, session_id and session_repetition in this table.
@@ -67,10 +56,7 @@ tables:
     name: activity_index
     type: index
     requirement: optional
-    description: When subjects complete multiple activities (e.g., a cognitive test followed by a questionnaire),
-      this variable indicates the order of each activity (i.e., the first activity completed by the subject
-      has `activity_index` = 1, the second session has `activity_index` = 2; even if the second activity
-      is an exact repetition of the first one.
+    description: When subjects complete multiple activities (e.g., a cognitive test followed by a questionnaire), this variable indicates the order of each activity (i.e., the first activity completed by the subject has `activity_index` = 1, the second session has `activity_index` = 2; even if the second activity is an exact repetition of the first one.
     range: 1-based index of activity within the subject-level data.
     notes:
     - See `Studyflow` table for more details.
@@ -79,52 +65,41 @@ tables:
     name: language
     type: string
     requirement: optional
-    description: The language the task was completed in, expressed as a two-letter code within the [ISO_639-1
-      standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+    description: The language the task was completed in, expressed as a two-letter code within the [ISO_639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
   - categories:
     - Task
     name: instrument_id
     type: string
     requirement: required
-    description: The unique identifier of the instrument used for collecting data (e.g., the name of the
-      computer script used to run the test). Unique in the `Instrument` table and corresponding files
-      in the `instruments/` folder.
+    description: The unique identifier of the instrument used for collecting data (e.g., the name of the computer script used to run the test). Unique in the `Instrument` table and corresponding files in the `instruments/` folder.
     range: '`id` in the `Instrument` table.'
   - categories:
     - Task
     name: instrument_repetition
     type: integer
     requirement: optional
-    description: The number of times this particular instrument has already been completed anytime in
-      the past by this particular subject in this study. This variable has a value 0 the first time an
-      instrument is used.
+    description: The number of times this particular instrument has already been completed anytime in the past by this particular subject in this study. This variable has a value 0 the first time an instrument is used.
     range: 0-based
   - categories:
     - Task
     name: timeline_id
     type: string
     requirement: optional
-    description: Timelines are specific parameterization of an instrument and their identifiers are unique
-      within the corresponding table for the instrument in the `instruments/` folder.
+    description: Timelines are specific parameterization of an instrument and their identifiers are unique within the corresponding table for the instrument in the `instruments/` folder.
   - categories:
     - Task
     name: timeline_repetition
     type: integer
     requirement: optional
-    description: The number of times this particular timeline has already been completed anytime in the
-      past by this particular subject in this study. This variable has a value 0 the first time a timeline
-      is completed.
+    description: The number of times this particular timeline has already been completed anytime in the past by this particular subject in this study. This variable has a value 0 the first time a timeline is completed.
     range: 0-based
   - categories:
     - Task
     name: multitask_type
     type: enum
     requirement: required
-    description: Subjects may be required to perform multiple tasks at the same time. This variable indicates
-      the type of multitasking required.
-    range: '- Empty: No multitasking, i.e., single-tasking. - `concurrent`: There are two independent
-      tasks that need to be completed in parallel. - `compound`: The task requires multiple successive
-      stages or involves tasks that are dependent/coupled.'
+    description: Subjects may be required to perform multiple tasks at the same time. This variable indicates the type of multitasking required.
+    range: '- Empty: No multitasking, i.e., single-tasking. - `concurrent`: There are two independent tasks that need to be completed in parallel. - `compound`: The task requires multiple successive stages or involves tasks that are dependent/coupled.'
     notes:
     - If no multitasking was involved, leave this field blank.
     - This characterization of `multitasking_type` is rudimentary and will likely evolve in the future.
@@ -133,103 +108,72 @@ tables:
     name: task_index
     type: index
     requirement: optional
-    description: when `multitask_type` is not empty, `task_index` refers to each of the individual tasks.
-      For example, for auditoy-visual dual N-back, `task_index=1` is the auditory task and `task_index=2`
-      is the visual task.
+    description: when `multitask_type` is not empty, `task_index` refers to each of the individual tasks. For example, for auditoy-visual dual N-back, `task_index=1` is the auditory task and `task_index=2` is the visual task.
     range: 1-based index.
   - categories:
     - Task
     name: job_type
     type: string
     requirement: optional
-    description: The general type of operation the subject needs to perform. The job typically is expressed
-      as a verb (e.g., "recall", "sort") and can be the same for different instruments (e.g., Digit Span
-      test and Spatial Span test both have a job of type "recall-forward").
+    description: The general type of operation the subject needs to perform. The job typically is expressed as a verb (e.g., "recall", "sort") and can be the same for different instruments (e.g., Digit Span test and Spatial Span test both have a job of type "recall-forward").
   - categories:
     - Task
     name: job_description
     type: string
     requirement: optional
-    description: The more specific description of a job, which gives more information about what the participant
-      sees and has to do. Whereas the `job_type` typically uses only verbs and adjectives, the `job_description`
-      also contains nouns (e.g., “recall-digits-forward”, “recall-letters-backward”).
+    description: The more specific description of a job, which gives more information about what the participant sees and has to do. Whereas the `job_type` typically uses only verbs and adjectives, the `job_description` also contains nouns (e.g., “recall-digits-forward”, “recall-letters-backward”).
   - categories:
     - Task
     name: job_repeat
     type: enum
     requirement: optional
-    description: Whether this trial's job has not been seen before in this timeline (i.e., specific version
-      of the instrument).
-    range: '- `new`: The job has never been seen before by this subject in the current study. - `repeat`:
-      The job is the same as the previous trial. - `switch`: The job is different from the previous trial
-      but has been seen prior in the timeline.'
+    description: Whether this trial's job has not been seen before in this timeline (i.e., specific version of the instrument).
+    range: '- `new`: The job has never been seen before by this subject in the current study. - `repeat`: The job is the same as the previous trial. - `switch`: The job is different from the previous trial but has been seen prior in the timeline.'
   - categories:
     - Task
     name: block_index
     type: index
     requirement: required
-    description: Refers to the order in which this block has been experienced by the subject. When there
-      are multiple blocks, this variable indicates the order of each block (i.e., the first block completed
-      by the subject has `block_index=1`, the second block has `block_index=2`, even if the second block
-      is an exact repetition of the first one).
+    description: Refers to the order in which this block has been experienced by the subject. When there are multiple blocks, this variable indicates the order of each block (i.e., the first block completed by the subject has `block_index=1`, the second block has `block_index=2`, even if the second block is an exact repetition of the first one).
     range: 1-based index of the block within the timeline
     notes:
-    - In questionnaires, `block_index` may refer to distinct pages where each page may contain multiple
-      questions.
+    - In questionnaires, `block_index` may refer to distinct pages where each page may contain multiple questions.
   - categories:
     - Task
     name: block_name
     type: string
     requirement: optional
-    description: The name of a particular block in a timeline. If the same block is completed twice in
-      a row, they would have different `block_index` values (1 and 2, respectively) but they would have
-      the same `block_name` (e.g., “NB_timeline1_block1”). More details about the `block_name` is available
-      in the `Instrument` table.
+    description: The name of a particular block in a timeline. If the same block is completed twice in a row, they would have different `block_index` values (1 and 2, respectively) but they would have the same `block_name` (e.g., “NB_timeline1_block1”). More details about the `block_name` is available in the `Instrument` table.
   - categories:
     - Task
     name: block_type
     type: enum
     requirement: required
     description: Specifies the experimental role of the block (e.g., tutorial, practice, test, instruction).
-    range: '- `tutorial`: A simplified version of the test designed to teach participants how the test
-      works. - `practice`: Typically identical to the main test blocks but are used to get subjects accustomed
-      to the task in a no-stakes environment. - `test`: Primary blocks used to measure the desired behaviors.
-      - `instruction`: Presents written and/or visual instructions to the subject.'
+    range: '- `tutorial`: A simplified version of the test designed to teach participants how the test works. - `practice`: Typically identical to the main test blocks but are used to get subjects accustomed to the task in a no-stakes environment. - `test`: Primary blocks used to measure the desired behaviors. - `instruction`: Presents written and/or visual instructions to the subject.'
   - categories:
     - Task
     name: transformation_name
     type: string
     requirement: required
-    description: Refers to the specific events-to-trials function used to construct rows of this table
-      from raw events. The transformation (or projection in DDD terminology) embodies the definition of
-      a trial for a particular task. The transformer name refers to a code in the format of a function
-      `f(trial_state, event) => trial_state`, where `event` is the event occurred during the performance
-      of the task, and `trial_state` is the data stored for the trial. The final state of a trial is thus
-      the result of applying a sequence of projections such that `trial = f(f(f(initial()), e), e), e)`.'
+    description: Refers to the specific events-to-trials function used to construct rows of this table from raw events. The transformation (or projection in DDD terminology) embodies the definition of a trial for a particular task. The transformer name refers to a code in the format of a function `f(trial_state, event) => trial_state`, where `event` is the event occurred during the performance of the task, and `trial_state` is the data stored for the trial. The final state of a trial is thus the result of applying a sequence of projections such that `trial = f(f(f(initial()), e), e), e)`.'
     notes:
-    - '- The transformation/projection encapsulates the domain rules that define a "trial" for a given
-      task. It defines what constitutes a "trial".'
+    - '- The transformation/projection encapsulates the domain rules that define a "trial" for a given task. It defines what constitutes a "trial".'
   - categories:
     - Task
     name: trial_index
     type: id
     requirement: required
-    description: Sequential identifier representing number of times transformation rule to the events
-      occurred. It increases with each re-computation of the trial based on updated or newly received
-      events.
+    description: Sequential identifier representing number of times transformation rule to the events occurred. It increases with each re-computation of the trial based on updated or newly received events.
     range: Preferably 1-based integer index.
     notes:
-    - This field emphasizes order of trials and alignment with projection-based definition of trials.
-      A more complete name would be `projection_index` or `pojected_trial_index`. For brevity, BDM uses
-      `trial_id` instead.
+    - This field emphasizes order of trials and alignment with projection-based definition of trials. A more complete name would be `projection_index` or `pojected_trial_index`. For brevity, BDM uses `trial_id` instead.
   - categories:
     - Task
     name: episode_index
     type: index
     requirement: optional
-    description: Episodes are temporally distinct bins of time (no overlap and discrete). The binning
-      of the time into successive episodes depends on the task; it is mostly used and necessary to group
-      data in cases where two distinct trials occurred at the same time (e.g., dual N-back).
+    description: Episodes are temporally distinct bins of time (no overlap and discrete). The binning of the time into successive episodes depends on the task; it is mostly used and necessary to group data in cases where two distinct trials occurred at the same time (e.g., dual N-back).
     range: 1-based interger index.
   - categories:
     - Task
@@ -248,9 +192,7 @@ tables:
     name: stimulus_index
     type: list[index]
     requirement: optional
-    description: Indexes in chronological (or spatial) order the stimuli shown within an instrument (counting
-      one stimulus per response). `stimulus_index` may for instance be used to refer to the nth question
-      asked within a questionnaire.
+    description: Indexes in chronological (or spatial) order the stimuli shown within an instrument (counting one stimulus per response). `stimulus_index` may for instance be used to refer to the nth question asked within a questionnaire.
     notes:
     - Use semicolon-separated indices if more then one stimulus were presented, e.g., `1;2;3`.
   - categories:
@@ -258,19 +200,14 @@ tables:
     name: stimulus_id
     type: integer
     requirement: required
-    description: Is a unique identifier for the (unitary, set or sequence of) stimuli presented during
-      a trial; if those exact same stimuli are repeated in a different trial, that trial would have the
-      same value for stimulus_id. stimulus_id may also be used to refer to a specific message or question
-      in a questionnaire.
+    description: Is a unique identifier for the (unitary, set or sequence of) stimuli presented during a trial; if those exact same stimuli are repeated in a different trial, that trial would have the same value for stimulus_id. stimulus_id may also be used to refer to a specific message or question in a questionnaire.
   - categories:
     - Stimulus
     name: stimulus_type
     type: enum
     requirement: required
     description: 'BDM distinguishes the following stimulus types: messages and questions'
-    range: '- `message`: The stimulus is a message shown to subjects (e.g., task instructions). - `question`:
-      The stimulus may consist of text, images and/or sounds; they require subjects to make a decision
-      based on the content of the stimulus.'
+    range: '- `message`: The stimulus is a message shown to subjects (e.g., task instructions). - `question`: The stimulus may consist of text, images and/or sounds; they require subjects to make a decision based on the content of the stimulus.'
   - categories:
     - Stimulus
     name: stimulus_onset
@@ -283,46 +220,35 @@ tables:
     name: stimulus_panel_count
     type: integer
     requirement: optional
-    description: The number of panels or screen areas stimuli may appear on during the trial. For example,
-      in a task where stimuli to be compared are presented on the left and right side of the screen, stimulus_panel_count
-      = 2.
+    description: The number of panels or screen areas stimuli may appear on during the trial. For example, in a task where stimuli to be compared are presented on the left and right side of the screen, stimulus_panel_count = 2.
   - categories:
     - Stimulus
     name: stimulus_structure
     type: enum
     requirement: optional
     description: 'We distinguish three stimulus structures: unitary, set, sequence'
-    range: '- `unitary`: Only one stimulus is shown, alone. - `set`: Many stimuli are shown, either at
-      the same time or not; order does not matter. - `sequence`: Multiple stimuli are shown, either at
-      the same time or not; order does matter (order may be indicated by the order of presentation or
-      by a digit for example).'
+    range: '- `unitary`: Only one stimulus is shown, alone. - `set`: Many stimuli are shown, either at the same time or not; order does not matter. - `sequence`: Multiple stimuli are shown, either at the same time or not; order does matter (order may be indicated by the order of presentation or by a digit for example).'
   - categories:
     - Stimulus
     name: stimulus_structure_source_type
     type: enum
     requirement: optional
-    description: 'Indicates the type of method used to generate the stimulus_structure (this is relevant
-      when a trial displays a sequence of or set of stimuli): none, preset, generator'
-    range: '- `none`: when stimulus_structure == unitary.", - `preset`: The structure of stimuli is hard
-      coded in a file. - `generator`: A procedure was used to generate the stimulus_structure.'
+    description: 'Indicates the type of method used to generate the stimulus_structure (this is relevant when a trial displays a sequence of or set of stimuli): none, preset, generator'
+    range: '- `none`: when stimulus_structure == unitary.", - `preset`: The structure of stimuli is hard coded in a file. - `generator`: A procedure was used to generate the stimulus_structure.'
   - categories:
     - Stimulus
     name: stimulus_structure_source
     type: string
     requirement: optional
-    description: Refers to the specific generator used to produce the stimulus_structure (e.g., sequence
-      of digits in a digit span test). When no generator was used, this variable has a value of none.
+    description: Refers to the specific generator used to produce the stimulus_structure (e.g., sequence of digits in a digit span test). When no generator was used, this variable has a value of none.
   - categories:
     - Stimulus
     name: stimulus_set_size
     type: integer
     requirement: optional
-    description: The number of different values each presented stimulus could have taken. This value gives
-      an indication of the complexity of the stimulus space. When this number is large we set this variable
-      to infinity, when for any reason it was not computed, it has a value of NA.
+    description: The number of different values each presented stimulus could have taken. This value gives an indication of the complexity of the stimulus space. When this number is large we set this variable to infinity, when for any reason it was not computed, it has a value of NA.
     notes:
-    - To specify "infinity" in a CSV file we use +Inf and -Inf; these are correctly recognized in R (tidyverse)
-      and Python (pandas) as being valid numbers rather than strings.
+    - To specify "infinity" in a CSV file we use +Inf and -Inf; these are correctly recognized in R (tidyverse) and Python (pandas) as being valid numbers rather than strings.
   - categories:
     - Stimulus
     name: stimulus_count
@@ -335,93 +261,57 @@ tables:
     name: stimulus_source_type
     type: enum
     requirement: optional
-    description: A stimulus is typically created using a particular procedure/algorithm ("generator")
-      or is sampled from a particular set ("set"). This variable indicates which of these two applies
-      for the current stimulus.
-    range: '- "set":"stimulus is sampled from a fixed set of stimuli." - "generator": "stimulus is created
-      using a procedure/algorithm."'
+    description: A stimulus is typically created using a particular procedure/algorithm ("generator") or is sampled from a particular set ("set"). This variable indicates which of these two applies for the current stimulus.
+    range: '- "set":"stimulus is sampled from a fixed set of stimuli." - "generator": "stimulus is created using a procedure/algorithm."'
   - categories:
     - Stimulus
     name: stimulus_source
     type: string
     requirement: optional
-    description: Refers to the specific generator or set the stimulus belongs to. Stimuli that stem from
-      the same source have the same data scheme and could thus be described in a table named after stimulus_source
-      (i.e., stimulus_source indicates which table contains the full information about the stimulus; e.g.,
-      "digit1to9").
+    description: Refers to the specific generator or set the stimulus belongs to. Stimuli that stem from the same source have the same data scheme and could thus be described in a table named after stimulus_source (i.e., stimulus_source indicates which table contains the full information about the stimulus; e.g., "digit1to9").
   - categories:
     - Stimulus
     name: stimulus_index_in_source
     type: integer
     requirement: optional
-    description: 'Index of the stimulus within the table referred to by stimulus_source. : For example,
-      if stimulus_source == "digit1to9", stimulus_index_in_source = 1 refers to "1" while for stimulus_source
-      == "LettersAtoD", stimulus_index_in_source = 1 refers to "A".'
+    description: 'Index of the stimulus within the table referred to by stimulus_source. : For example, if stimulus_source == "digit1to9", stimulus_index_in_source = 1 refers to "1" while for stimulus_source == "LettersAtoD", stimulus_index_in_source = 1 refers to "A".'
     notes:
-    - It is not because a particular stimulus_source is used in a given timeline that all possible stimuli
-      of that source are displayed to the user. For example, the AX-CPT may use "upper-case-letters" but
-      only use a subset of those letters (e.g., "A", "B", "X", "Y"). Whenever possible, we specify the
-      most relevant/specific set (e.g., "digit1to9" rather than "digit").
+    - It is not because a particular stimulus_source is used in a given timeline that all possible stimuli of that source are displayed to the user. For example, the AX-CPT may use "upper-case-letters" but only use a subset of those letters (e.g., "A", "B", "X", "Y"). Whenever possible, we specify the most relevant/specific set (e.g., "digit1to9" rather than "digit").
   - categories:
     - Stimulus
     name: stimulus_position_index
     type: integer
     requirement: optional
-    description: Refers to discrete positions on the screen the stimulus may appear on. The set and ordering
-      of possible positions depends on the test. Whenever possible, it follows a natural order (left to
-      right, top to bottom), but in free-form layouts, indices are arbitrary.
+    description: Refers to discrete positions on the screen the stimulus may appear on. The set and ordering of possible positions depends on the test. Whenever possible, it follows a natural order (left to right, top to bottom), but in free-form layouts, indices are arbitrary.
   - categories:
     - Stimulus
     name: stimulus_description
     type: string
     requirement: optional
-    description: A human readable, compact description of the main aspects of the stimulus. The description
-      for a given stimulus depends on the task but follows a specific template for a given task. Because
-      of this, it looks like the stimulus_description could be "parsed" and "tidied"---however, this is
-      not the intention; parsed/tidied data will be available in other tables; description is for human
-      readability and facilitates the understanding of the data.
+    description: A human readable, compact description of the main aspects of the stimulus. The description for a given stimulus depends on the task but follows a specific template for a given task. Because of this, it looks like the stimulus_description could be "parsed" and "tidied"---however, this is not the intention; parsed/tidied data will be available in other tables; description is for human readability and facilitates the understanding of the data.
     notes:
-    - In some cases, when stimuli are too complex or can't be precisely described, a summary of all stimuli
-      is given instead.
+    - In some cases, when stimuli are too complex or can't be precisely described, a summary of all stimuli is given instead.
   - categories:
     - Stimulus
     name: stimulus_role
     type: enum
     requirement: optional
-    description: 'A stimulus may play different roles within a trial. Below is a list of some possible
-      roles:'
-    range: '- "target": "A stimulus the subject must process and which should trigger the completion of
-      the response (e.g., classify, reach, memorize) if the subject is doing the task as intended. Note
-      that in some cases (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click
-      the button. In this case, the stimulus that triggered the decision to NOT click the button is still
-      a *target*." - "non_target": "A stimulus the subject must process but which does not trigger the
-      completion of the response (e.g., the first two stimuli in a 2-back test)." - "distractor": "A stimulus
-      the subject should not process at all (i.e., ignore) and which is unrelated to the correct execution
-      of the task." - "location_cue": "A stimulus giving a spatial location information that subjects
-      could use to improve their performance." - "job_specifier": "A stimulus specifying which job the
-      subject should perform." - "stop_signal": "A stimulus signaling the participant he should abort
-      his current action." - "probe": "A stimulus indicating about which stimulus to respond."'
+    description: 'A stimulus may play different roles within a trial. Below is a list of some possible roles:'
+    range: '- "target": "A stimulus the subject must process and which should trigger the completion of the response (e.g., classify, reach, memorize) if the subject is doing the task as intended. Note that in some cases (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click the button. In this case, the stimulus that triggered the decision to NOT click the button is still a *target*." - "non_target": "A stimulus the subject must process but which does not trigger the completion of the response (e.g., the first two stimuli in a 2-back test)." - "distractor": "A stimulus the subject should not process at all (i.e., ignore) and which is unrelated to the correct execution of the task." - "location_cue": "A stimulus giving a spatial location information that subjects could use to improve their performance." - "job_specifier": "A stimulus specifying which job the subject should perform." - "stop_signal": "A stimulus signaling the participant he should abort his current action." - "probe": "A stimulus indicating about which stimulus to respond."'
   - categories:
     - Option
     name: option_source_type
     type: enum
     requirement: optional
-    description: A set of options is typically created using a particular procedure/algorithm (“generator”)
-      or is sampled from a particular set (“set”). This variable indicates which of these two applies
-      for the current options.
+    description: A set of options is typically created using a particular procedure/algorithm (“generator”) or is sampled from a particular set (“set”). This variable indicates which of these two applies for the current options.
   - categories:
     - Option
     name: option_source
     type: string
     requirement: optional
-    description: Refers to the specific generator or set that determined the options on a given trial.
-      Option that stem from the same source have the same data scheme and could thus be described in a
-      table named after option_source (i.e., option_source indicates which table contains the full information
-      about the option set).
+    description: Refers to the specific generator or set that determined the options on a given trial. Option that stem from the same source have the same data scheme and could thus be described in a table named after option_source (i.e., option_source indicates which table contains the full information about the option set).
     notes:
-    - While there is a stimulus_index_in_source to refer to the particular stimulus that was used, we
-      don’t have an equivalent opiton_index_in_source since all options are displayed. Instead, we use
-      response_index and expected_response_index to refer to a particular option within the set of options.
+    - While there is a stimulus_index_in_source to refer to the particular stimulus that was used, we don’t have an equivalent opiton_index_in_source since all options are displayed. Instead, we use response_index and expected_response_index to refer to a particular option within the set of options.
   - categories:
     - Option
     name: option_count
@@ -440,43 +330,30 @@ tables:
     type: enum
     requirement: optional
     description: 'Describes the type of data this option entails. Possible values include:'
-    range: '- "nominal": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - "ordinal":
-      "Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - "interval": Ordered
-      values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - "ratio":
-      Values with clear distance metrics and absolute zero (e.g., length in cm).'
+    range: '- "nominal": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - "ordinal": "Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - "interval": Ordered values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - "ratio": Values with clear distance metrics and absolute zero (e.g., length in cm).'
   - categories:
     - Option
     name: measurement_type
     type: enum
     requirement: optional
-    description: 'Describes the type of measurement implied by Option which in turn has implications on
-      how that data should be processed during analysis; takes a value in:'
-    range: '- "nominal": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - "ordinal":
-      "Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - "interval": Ordered
-      values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - "ratio":
-      Values with clear distance metrics and absolute zero (e.g., length in cm).'
+    description: 'Describes the type of measurement implied by Option which in turn has implications on how that data should be processed during analysis; takes a value in:'
+    range: '- "nominal": Set of unordered labels (e.g., {“Luxembourg”, “France”, “Germany”}). - "ordinal": "Ordered values without clear distance (e.g., {“a lot”, “a bit”, “not at all”}). - "interval": Ordered values with clear distances but no absolute zero (e.g., 10 versus 20 degrees Celsius). - "ratio": Values with clear distance metrics and absolute zero (e.g., length in cm).'
   - categories:
     - Input
     name: input_interface_type
     type: enum
     requirement: optional
-    description: 'Refers to the type of interface subjects used to input actions. Possible values include
-      (non-exhaustive):'
-    range: '- `keyboard`: A keyboard is displayed on the screen. - `buttons`: Dedicated buttons on the
-      screen. - `stimulus-button`: Stimuli serves as buttons. - `text-field`: A text field is displayed
-      on the screen. - `slider`: A slider is displayed on the screen.'
+    description: 'Refers to the type of interface subjects used to input actions. Possible values include (non-exhaustive):'
+    range: '- `keyboard`: A keyboard is displayed on the screen. - `buttons`: Dedicated buttons on the screen. - `stimulus-button`: Stimuli serves as buttons. - `text-field`: A text field is displayed on the screen. - `slider`: A slider is displayed on the screen.'
   - categories:
     - Input
     name: input_action_type
     type: enum
     requirement: optional
-    description: 'Refers to the type of action the subject performs to give a response. Possible values
-      include (non-exhaustive):'
-    range: '- "mouse-click" - "mouse-release" - "key-press" - "key-release" - "mouse-drag" - "touch" -
-      "swipe"'
+    description: 'Refers to the type of action the subject performs to give a response. Possible values include (non-exhaustive):'
+    range: '- "mouse-click" - "mouse-release" - "key-press" - "key-release" - "mouse-drag" - "touch" - "swipe"'
     notes:
-    - The type of input_action determines the structure of detailed response data (i.e., mouse-click data
-      is different from key-press data).
+    - The type of input_action determines the structure of detailed response data (i.e., mouse-click data is different from key-press data).
   - categories:
     - Input
     name: input_count
@@ -493,10 +370,7 @@ tables:
     description: The index of the option the subject is expected to choose from the set of options.
     notes:
     - When expected_response_index = 0, it means that the subject should not respond at all.
-    - Sometimes stimuli serve both as stimuli and as response options as subjects have to click on a particular
-      stimuli to give their response (e.g., spatial span, odd one out). It is convenient in those cases
-      to use stimulus_position_index to order/index the options (i.e., option_index == stimulus_position_index)
-      and consequently also the responses.
+    - Sometimes stimuli serve both as stimuli and as response options as subjects have to click on a particular stimuli to give their response (e.g., spatial span, odd one out). It is convenient in those cases to use stimulus_position_index to order/index the options (i.e., option_index == stimulus_position_index) and consequently also the responses.
   - categories:
     - Expectation
     name: expected_response_description
@@ -509,34 +383,18 @@ tables:
     type: string
     requirement: optional
     description: 'The structure of the response required by the subject; can take values in:'
-    range: '- `unitary`: The subject provides a single input (e.g., chooses option *same*). - `set`: The
-      subject provides a set of information, and the order does not matter (e.g., list words that start
-      with the letter *A*). - `sequence`: The subject provides a sequence of information, and the order
-      matters (e.g., a sequence of memorized digits in their order of appearance).'
+    range: '- `unitary`: The subject provides a single input (e.g., chooses option *same*). - `set`: The subject provides a set of information, and the order does not matter (e.g., list words that start with the letter *A*). - `sequence`: The subject provides a sequence of information, and the order matters (e.g., a sequence of memorized digits in their order of appearance).'
     notes:
-    - Note that the distinction between set and sequence refers to the importance of order information
-      to evaluate if the response is correct or not; a response with a set structure may unfold over time
-      (each piece of information is given in a particular temporal order) and it may be of scientific
-      interest to take into account that order; however, the order itself is not important within the
-      task itself. For example, in the [MOT task](https://en.wikipedia.org/wiki/Multiple_object_tracking)
-      one may ask subjects to point to all dots that hide a token. If subjects point to all such dots
-      they will be correct no matter in which order the dots were clicked in.
+    - Note that the distinction between set and sequence refers to the importance of order information to evaluate if the response is correct or not; a response with a set structure may unfold over time (each piece of information is given in a particular temporal order) and it may be of scientific interest to take into account that order; however, the order itself is not important within the task itself. For example, in the [MOT task](https://en.wikipedia.org/wiki/Multiple_object_tracking) one may ask subjects to point to all dots that hide a token. If subjects point to all such dots they will be correct no matter in which order the dots were clicked in.
   - categories:
     - Response
     name: response_count
     type: integer
     requirement: optional
-    description: Each trial contains by definition only one response. However, when response_structure
-      is other than unitary, a response comprises multiple pieces of information (e.g., “3-5-7” could
-      be one response in the digit span task and this response contains three components, namely “3”,
-      “5” and “7”). response_count refers to the number of components that make up a response (not the
-      number of responses within a trial).
+    description: Each trial contains by definition only one response. However, when response_structure is other than unitary, a response comprises multiple pieces of information (e.g., “3-5-7” could be one response in the digit span task and this response contains three components, namely “3”, “5” and “7”). response_count refers to the number of components that make up a response (not the number of responses within a trial).
     notes:
-    - response_count is different from input_count; a subject may in some cases change their response
-      multiple times before submitting the final response. In such cases, there would be many more inputs
-      than there are components to the final response.
-    - While we have stimulus_set_size we currently don’t have a response_set_size, but we do have option_count
-      and response_count.
+    - response_count is different from input_count; a subject may in some cases change their response multiple times before submitting the final response. In such cases, there would be many more inputs than there are components to the final response.
+    - While we have stimulus_set_size we currently don’t have a response_set_size, but we do have option_count and response_count.
   - categories:
     - Response
     name: response_option_index
@@ -544,8 +402,7 @@ tables:
     requirement: optional
     description: The index of the option the participant chose, starting from 1.
     notes:
-    - response_option_index = 0 means the subject chose none of the options (e.g., a “no-go” response
-      in a Go/No-go task).
+    - response_option_index = 0 means the subject chose none of the options (e.g., a “no-go” response in a Go/No-go task).
     - response_index can be directly compared to expected_response_index.
     - response_index refers to an entry in the Option table (i.e., there is no Response table).
   - categories:
@@ -553,8 +410,7 @@ tables:
     name: response_description
     type: string
     requirement: optional
-    description: A description of participant’s response; typically the description of the option that
-      was chosen.
+    description: A description of participant’s response; typically the description of the option that was chosen.
     notes:
     - response_description can be directly compared to expected_response_description.
   - categories:
@@ -562,18 +418,13 @@ tables:
     name: response_numeric
     type: float
     requirement: optional
-    description: A numeric value associated with a particular response; this could be a numeric value
-      entered directly by the subject or the numeric meaning of a selected option (for example, the choice
-      of option "Never" may be associated with the numeric value of 0). Note that this variable describes
-      the subject's response; it does not describe the value (e.g., correctness or goodness) that is associated
-      with that response.
+    description: A numeric value associated with a particular response; this could be a numeric value entered directly by the subject or the numeric meaning of a selected option (for example, the choice of option "Never" may be associated with the numeric value of 0). Note that this variable describes the subject's response; it does not describe the value (e.g., correctness or goodness) that is associated with that response.
   - categories:
     - Response
     name: response_time
     type: float
     requirement: optional
-    description: The duration, in seconds, between the earliest possible time a response could have been
-      completed and the moment that response was actually completed (and NOT when it was initiated).
+    description: The duration, in seconds, between the earliest possible time a response could have been completed and the moment that response was actually completed (and NOT when it was initiated).
   - categories:
     - Response
     name: response_datetime
@@ -585,15 +436,13 @@ tables:
     name: response_validation_time
     type: float
     requirement: optional
-    description: In some cases, subjects may need to press an extra key to validate previous responses.
-      When relevant, this variable may encode this duration.
+    description: In some cases, subjects may need to press an extra key to validate previous responses. When relevant, this variable may encode this duration.
   - categories:
     - Response
     name: response_initiation_time
     type: float
     requirement: optional
-    description: In some cases (e.g., a reaching movement) it might be useful to encode when a response
-      was initiated.
+    description: In some cases (e.g., a reaching movement) it might be useful to encode when a response was initiated.
   - categories:
     - Response
     name: response_skipped
@@ -605,8 +454,7 @@ tables:
     name: timed_out
     type: boolean
     requirement: optional
-    description: Some tasks require subjects to give a response within a certain time limit. When subjects
-      fail to respond before that time runs out, timed_out is set to TRUE.
+    description: Some tasks require subjects to give a response within a certain time limit. When subjects fail to respond before that time runs out, timed_out is set to TRUE.
   - categories:
     - Evaluation
     name: accuracy
@@ -618,79 +466,48 @@ tables:
     name: correct
     type: boolean
     requirement: optional
-    description: Indicates whether the response matches the expected response (i.e., correct = TRUE) or
-      not (i.e., correct = FALSE).
+    description: Indicates whether the response matches the expected response (i.e., correct = TRUE) or not (i.e., correct = FALSE).
   - categories:
     - Evaluation
     name: score
     type: float
     requirement: optional
-    description: A numeric value associated with a particular response in a given context. This variable
-      may be used to compute a performance metric or a questionnaire level index (e.g., a well-being score).
+    description: A numeric value associated with a particular response in a given context. This variable may be used to compute a performance metric or a questionnaire level index (e.g., a well-being score).
   - categories:
     - Evaluation
     name: evaluation_label
     type: enum
     requirement: optional
-    description: 'There are several labels that can be assigned to a given response to specify what that
-      response means in terms of evaluation within a task. The most general terms are "correct” and "error"
-      (which are already given by the correct variable). There are however more specific sets of terms
-      that may apply in different contexts. For example, in a signal detection task, it is common to use
-      labels from the signal detection theory framework (i.e., “hit”, “miss”, “false alarm”, “correct
-      rejection”). In other contexts, researchers might use terms like “omission” or “commission” errors
-      or even things like “perseveration” error (e.g., in the Wisconsin Card Sorting Test). Note that
-      these terms are not always well defined or exclusive. For example, a “hit” is also a “correct” response
-      and a “false alarm” may be synonymous to “commission error”. Whenever possible use the more specific
-      terms (i.e., always use “hit” rather than “correct” when applicable). Here are few evaluation labels
-      that are commonly used:'
-    range: '- `correct`: The response is correct. - `error`: The response is incorrect. - `hit`: The stimulus
-      was *present* and the subject correctly responded *present*. - `miss`: The stimulus was *present*
-      and the subject correctly responded *absent*. - `fa`: The stimulus was *absent* and the subject
-      correctly responded *present*. - `cr`: The stimulus was *absent* and the subject correctly responded
-      *absent*.'
+    description: 'There are several labels that can be assigned to a given response to specify what that response means in terms of evaluation within a task. The most general terms are "correct” and "error" (which are already given by the correct variable). There are however more specific sets of terms that may apply in different contexts. For example, in a signal detection task, it is common to use labels from the signal detection theory framework (i.e., “hit”, “miss”, “false alarm”, “correct rejection”). In other contexts, researchers might use terms like “omission” or “commission” errors or even things like “perseveration” error (e.g., in the Wisconsin Card Sorting Test). Note that these terms are not always well defined or exclusive. For example, a “hit” is also a “correct” response and a “false alarm” may be synonymous to “commission error”. Whenever possible use the more specific terms (i.e., always use “hit” rather than “correct” when applicable). Here are few evaluation labels that are commonly used:'
+    range: '- `correct`: The response is correct. - `error`: The response is incorrect. - `hit`: The stimulus was *present* and the subject correctly responded *present*. - `miss`: The stimulus was *present* and the subject correctly responded *absent*. - `fa`: The stimulus was *absent* and the subject correctly responded *present*. - `cr`: The stimulus was *absent* and the subject correctly responded *absent*.'
   - categories:
     - Feedback
     name: feedback_description
     type: string
     requirement: optional
-    description: 'Lists the different kinds of feedback that were shown on a given trial. When multiple
-      types of feedback were used, feedback will list them using `;` as a separator. If a given type of
-      feedback was shown multiple times during a trial, that feedback type is listed only once (i.e.,
-      feedback_description does NOT represent the sequence of feedbacks). The possible values for feedback
-      are:'
-    range: '- `none`: No feedback was shown. - `expected_response`: Feedback indicated what the correct
-      response would have been. - `explanation`: Feedback explains *why* a certain option is the correct
-      one. - `correctness_on_option`: "Feedback indicates (on the option itself) if the option chosen
-      by the participant was the correct one (e.g., in green), or not (e.g., in red). - `correctness_on_screen`:
-      "Feedback displayed on the screen center indicates if the response to the current trial was correct
-      or not (e.g., using a green check or a red cross).'
+    description: 'Lists the different kinds of feedback that were shown on a given trial. When multiple types of feedback were used, feedback will list them using `;` as a separator. If a given type of feedback was shown multiple times during a trial, that feedback type is listed only once (i.e., feedback_description does NOT represent the sequence of feedbacks). The possible values for feedback are:'
+    range: '- `none`: No feedback was shown. - `expected_response`: Feedback indicated what the correct response would have been. - `explanation`: Feedback explains *why* a certain option is the correct one. - `correctness_on_option`: "Feedback indicates (on the option itself) if the option chosen by the participant was the correct one (e.g., in green), or not (e.g., in red). - `correctness_on_screen`: "Feedback displayed on the screen center indicates if the response to the current trial was correct or not (e.g., using a green check or a red cross).'
     notes:
-    - This list is not exhaustive and characterizing feedback in the future will involve more variables
-      (e.g., separating the type of information shown (e.g., correctness) and how it is shown (“on_option”
-      versus “on_screen”).
-    - 'NOTE2: We don’t consider here as “feedback”, the kind of feedback that is used in UI to confirm
-      to users that a button has indeed been clicked.'
+    - This list is not exhaustive and characterizing feedback in the future will involve more variables (e.g., separating the type of information shown (e.g., correctness) and how it is shown (“on_option” versus “on_screen”).
+    - 'NOTE2: We don’t consider here as “feedback”, the kind of feedback that is used in UI to confirm to users that a button has indeed been clicked.'
   - categories:
     - Outcome
     name: outcome_description
     type: string
     requirement: optional
-    description: Describes the observable consequences of the subject's response (e.g., "the opened box
-      is empty").
+    description: Describes the observable consequences of the subject's response (e.g., "the opened box is empty").
   - categories:
     - Outcome
     name: outcome_numeric
     type: float
     requirement: optional
-    description: A numeric value describing the observable consequences of the subject's response (e.g.,
-      +3 points).
+    description: A numeric value describing the observable consequences of the subject's response (e.g., +3 points).
   - categories:
     - Accessory
     name: additional_measures
     type: string
     requirement: optional
-    description: 'Indicates whether additional measures have been recorded during this trial and if so
-      what kind of measures they are. Possible values include (non-exhaustive):'
+    description: 'Indicates whether additional measures have been recorded during this trial and if so what kind of measures they are. Possible values include (non-exhaustive):'
     range: '- `mouse_trajectories` - `fmri` - `eye_tracking` - `heart_rate`'
     notes:
     - Leave this field empty if no additional measures were recorded for this specific response.
@@ -699,19 +516,15 @@ tables:
     name: adaptive_method_name
     type: enum
     requirement: optional
-    description: Specifies the adaptive procedure used to modify instrument parameters in response to
-      subject performance (e.g., `staircase`).
+    description: Specifies the adaptive procedure used to modify instrument parameters in response to subject performance (e.g., `staircase`).
   - categories:
     - Experimental Design
     name: adaptive_method_config
     type: string
     requirement: optional
-    description: More detailed configuration for the adaptive method, including initial values, step sizes,
-      and termination criteria.
+    description: More detailed configuration for the adaptive method, including initial values, step sizes, and termination criteria.
     notes:
-    - For example, `1up-2down`. The 1-up, 2-down is a common adaptive staircase procedure used to estimate
-      a subject's threshold or sensitivity. After a correct response, the difficulty level is increased,
-      and after two incorrect responses, the difficulty level is decreased.
+    - For example, `1up-2down`. The 1-up, 2-down is a common adaptive staircase procedure used to estimate a subject's threshold or sensitivity. After a correct response, the difficulty level is increased, and after two incorrect responses, the difficulty level is decreased.
   - categories:
     - Experimental Design
     name: adaptive_parameter_name
@@ -723,76 +536,59 @@ tables:
     name: adaptive_parameter_value
     type: any
     requirement: optional
-    description: The specific value of the instrument parameter that was used for this trial. This value
-      is updated as the adaptive algorithm adjusts the parameter based on the subject's responses.
+    description: The specific value of the instrument parameter that was used for this trial. This value is updated as the adaptive algorithm adjusts the parameter based on the subject's responses.
     range: Data type depends on the type of the adaptive parameter, as defined in `adaptive_parameter_name`)
   - categories:
     - Experimental Design
     name: adaptive_parameter_value_next
     type: any
     requirement: optional
-    description: The next value of the adaptive parameter that will be used in the subsequent trial, as
-      determined by the adaptive algorithm.
+    description: The next value of the adaptive parameter that will be used in the subsequent trial, as determined by the adaptive algorithm.
     range: Data type depends on the type of the adaptive parameter, as defined in `adaptive_parameter_name`)
 - name: Stimulus
   label: Stimulus
   description: Describes each of the stimuli that were shown during an trial.
   notes:
-  - Each row of `Stimulus` table corresponds to a stimulus in a trial. Each trial can contain different
-    number of stimuli.
+  - Each row of `Stimulus` table corresponds to a stimulus in a trial. Each trial can contain different number of stimuli.
   fields:
   - categories:
     - Key
     name: stimulus_id
     type: PRIMARY KEY
     requirement: required
-    description: Primary key of the `Stimulus` table. Reference to this identifier in other tables are
-      thus named `stimulus_id`.
+    description: Primary key of the `Stimulus` table. Reference to this identifier in other tables are thus named `stimulus_id`.
     range: Each row in this table has a unique `id`.
     notes:
-    - If the same stimulus is shown at two different times in a trial, those two instances will have their
-      own row in the `Stimulus` table, each with its own `id`.
-    - Make sure to refer to this field as `stimulus_id` rather than `id` When joining tables. This also
-      applies to all the `id` fields; they are named `id` within their own context/table, but `<context/table>_id`
-      when addressed from other tables. For example, `X_id` in a table refers (hence a foreign key) to
-      the `id` column in the X table.
+    - If the same stimulus is shown at two different times in a trial, those two instances will have their own row in the `Stimulus` table, each with its own `id`.
+    - Make sure to refer to this field as `stimulus_id` rather than `id` When joining tables. This also applies to all the `id` fields; they are named `id` within their own context/table, but `<context/table>_id` when addressed from other tables. For example, `X_id` in a table refers (hence a foreign key) to the `id` column in the X table.
   - categories:
     - Context
     name: trial_id
     type: id
     requirement: optional
-    description: Refers to the `trial_index` in the `Response` table and indicates in which trial this
-      stimulus was shown.
+    description: Refers to the `trial_index` in the `Response` table and indicates in which trial this stimulus was shown.
     range: '`trial_id` in the `Response` table of the same agent/session/activity/attempt'
   - categories:
     - Context
     name: response_id
     type: id
     requirement: required
-    description: Refers to the `response_id` in the `Response` table and indicates for which response
-      this stimulus was shown.
+    description: Refers to the `response_id` in the `Response` table and indicates for which response this stimulus was shown.
     range: '`response_id` in the `Response` table of the same agent/session/activity/attempt'
   - categories:
     - Context
     name: object_id
     type: string
     requirement: optional
-    description: A stimulus is defined by a set of features. This variable is used to identify each time
-      the same stimulus features were used.
+    description: A stimulus is defined by a set of features. This variable is used to identify each time the same stimulus features were used.
     notes:
-    - For example, if the same white digit "3" is shown in a digit span sequence, all those instances
-      would have the same `object_id` although they would have different `id`s (as they appeared at different
-      times).
+    - For example, if the same white digit "3" is shown in a digit span sequence, all those instances would have the same `object_id` although they would have different `id`s (as they appeared at different times).
   - categories:
     - Context
     name: presentation_id
     type: string
     requirement: optional
-    description: In a multitasking setting, a particular instance of a stimulus (e.g., the current letter
-      "A") may be used by multiple tasks at the same time (e.g, in the dual N-back task). Because these
-      are different trials, they will have different `trial_id` values and hence will have different rows
-      in the `Stimulus` table. We use `presentation_id` to indicate that a given stimulus is in fact the
-      same instance across those trials.
+    description: In a multitasking setting, a particular instance of a stimulus (e.g., the current letter "A") may be used by multiple tasks at the same time (e.g, in the dual N-back task). Because these are different trials, they will have different `trial_id` values and hence will have different rows in the `Stimulus` table. We use `presentation_id` to indicate that a given stimulus is in fact the same instance across those trials.
   - categories:
     - Context
     name: index_in_trial
@@ -814,8 +610,7 @@ tables:
     description: Describes for how long this stimulus was displayed after its onset, in seconds.
     range: In seconds
     notes:
-    - When the stimulus is shown using an animation, `duration` covers the complete period between the
-      start of the animation and the end of the animation.
+    - When the stimulus is shown using an animation, `duration` covers the complete period between the start of the animation and the end of the animation.
   - categories:
     - Where
     name: panel_id
@@ -829,9 +624,7 @@ tables:
     requirement: optional
     description: X coordinates of the stimulus on the screen in pixels.
     notes:
-    - In BDM, the preferred position is the center of the object. However, specific implementations of
-      the tasks may use other locations such as the top-left corner. If this is the case, it should be
-      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+    - In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
   - categories:
     - Where
     name: y_screen
@@ -857,11 +650,7 @@ tables:
     name: description
     type: string
     requirement: required
-    description: A human readable, compact description of the main aspects of the stimulus. The description
-      for a given stimulus depends on the task but follows a specific template for a given task. Because
-      of this, it looks like the `description` could be parsed and converted into a more structured format---however,
-      this is not the intention; structured data will be available in other tables; here, description
-      is for human readability and facilitates the understanding of the data.
+    description: A human readable, compact description of the main aspects of the stimulus. The description for a given stimulus depends on the task but follows a specific template for a given task. Because of this, it looks like the `description` could be parsed and converted into a more structured format---however, this is not the intention; structured data will be available in other tables; here, description is for human readability and facilitates the understanding of the data.
   - categories:
     - What
     name: source
@@ -869,128 +658,95 @@ tables:
     requirement: required
     description: Refers to the specific generator or set the stimulus belongs to.
     notes:
-    - Stimuli that come from the same source have the same data scheme and could thus be described in
-      a table named after the `stimulus_source`. `stimulus_source` indicates which table contains the
-      full information about the stimulus; e.g., "digits1to9".
-    - One could include a `source_count` variable here that indicates how many different stimuli there
-      are in the set; but it's better stored in the table that contains information about that stimulus
-      source.
+    - Stimuli that come from the same source have the same data scheme and could thus be described in a table named after the `stimulus_source`. `stimulus_source` indicates which table contains the full information about the stimulus; e.g., "digits1to9".
+    - One could include a `source_count` variable here that indicates how many different stimuli there are in the set; but it's better stored in the table that contains information about that stimulus source.
   - categories:
     - What
     name: source_type
     type: enum
     requirement: optional
-    description: A stimulus is typically created using a particular procedure/algorithm ("generator")
-      or is sampled from a particular set ("set"). This variable indicates which of these two applies
-      for the current stimulus.
-    range: '- `set`: stimulus is sampled from a fixed set of stimuli. - `generator`: "stimulus is created
-      using a procedure/algorithm.'
+    description: A stimulus is typically created using a particular procedure/algorithm ("generator") or is sampled from a particular set ("set"). This variable indicates which of these two applies for the current stimulus.
+    range: '- `set`: stimulus is sampled from a fixed set of stimuli. - `generator`: "stimulus is created using a procedure/algorithm.'
   - categories:
     - What
     name: index_in_source
     type: integer
     requirement: optional
-    description: When a stimulus is picked from a particular set (e.g., "digits1to9"), this index refers
-      to the index within that set.
+    description: When a stimulus is picked from a particular set (e.g., "digits1to9"), this index refers to the index within that set.
     notes:
-    - In addition to `index_in_source`, `stimulus_id` can also be used to look up further information
-      about the stimulus in the source.
+    - In addition to `index_in_source`, `stimulus_id` can also be used to look up further information about the stimulus in the source.
   - categories:
     - What
     name: role
     type: enum
     requirement: required
     description: Describe the role that the stimulus plays in the trial, e.g., "target".
-    range: '- `target`: A stimulus the agent must process and which should trigger the completion of the
-      response (e.g., classify, reach, memorize) if the agent is doing the task as intended. In some cases
-      (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click the button. In this
-      case, the stimulus that triggered the decision to NOT click the button is still a `target`. - `non_target`:
-      A stimulus the agent must process but which does not trigger the completion of the response (e.g.,
-      the first two stimuli in a 2-back test). - `distractor`: "A stimulus the agent should not process
-      at all (i.e., ignore) and which is unrelated to the correct execution of the task. - `location_cue`:
-      A stimulus giving a spatial location information that agents could use to improve their performance.
-      - `job_specifier`: A stimulus specifying which job the agent should perform. - `stop_signal`: "A
-      stimulus signaling the agents that they should abort current action. - `probe`: A stimulus indicating
-      about which stimulus to respond.'
+    range: '- `target`: A stimulus the agent must process and which should trigger the completion of the response (e.g., classify, reach, memorize) if the agent is doing the task as intended. In some cases (e.g., in a go/no-go task) the correct response to a stimulus is to NOT click the button. In this case, the stimulus that triggered the decision to NOT click the button is still a `target`. - `non_target`: A stimulus the agent must process but which does not trigger the completion of the response (e.g., the first two stimuli in a 2-back test). - `distractor`: "A stimulus the agent should not process at all (i.e., ignore) and which is unrelated to the correct execution of the task. - `location_cue`: A stimulus giving a spatial location information that agents could use to improve their performance. - `job_specifier`: A stimulus specifying which job the agent should perform. - `stop_signal`: "A stimulus signaling the agents that they should abort current action. - `probe`: A stimulus indicating about which stimulus to respond.'
   - categories:
     - How
     name: animation
     type: string
     requirement: optional
-    description: Describes the animation used to display a specific stimulus in a human-readable format.
-      For example, "fadeIn 3s" indicates a 3-second fade-in animation.
+    description: Describes the animation used to display a specific stimulus in a human-readable format. For example, "fadeIn 3s" indicates a 3-second fade-in animation.
     notes:
-    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common
-      animations (e.g., "3s linear slide-in").
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common animations (e.g., "3s linear slide-in").
 - name: Option
   label: Option
   description: Describes each option that a subject could choose from in a trial.
   notes:
-  - Note that in some tasks, the options may change within a trial after each input (e.g., serial self-ordered
-    search task); therefore the options are optionally indexed by `input_index`.
+  - Note that in some tasks, the options may change within a trial after each input (e.g., serial self-ordered search task); therefore the options are optionally indexed by `input_index`.
   fields:
   - categories:
     - Key
     name: option_id
     type: PRIMARY KEY
     requirement: required
-    description: Primary key of the `Option` table. Reference to this identifier in other tables are thus
-      named `option_id`.
+    description: Primary key of the `Option` table. Reference to this identifier in other tables are thus named `option_id`.
     range: Each row in this table has a unique `id`
     notes:
-    - If the same option is shown at two different times in a trial, those two instances will have their
-      own row in the * Option* table, each with its own `id`.
+    - If the same option is shown at two different times in a trial, those two instances will have their own row in the * Option* table, each with its own `id`.
   - categories:
     - Context
     name: trial_index
     type: id
     requirement: required
-    description: Refers to the `trial_index` in the `Response` table and indicates in which trial this
-      option was shown.
+    description: Refers to the `trial_index` in the `Response` table and indicates in which trial this option was shown.
     range: '`trial_index` in the `Response` table for the same subject/session/activity'
   - categories:
     - Context
     name: response_id
     type: id
     requirement: optional
-    description: Refers to the `response_id` in the `Response` table and indicates for which response
-      this option was shown.
+    description: Refers to the `response_id` in the `Response` table and indicates for which response this option was shown.
     range: '`response_id` in the `Response` table of the same subject/activity'
   - categories:
     - Context
     name: index_in_trial
     type: index
     requirement: optional
-    description: Indexing each of the options within the set of options that were available to subjects
-      on a given trial.
+    description: Indexing each of the options within the set of options that were available to subjects on a given trial.
     range: 1-based indices
     notes:
-    - If the presented options have no specific temporal or spatial order, leave this field empty or assign
-      the same index to all options, e.g., `index_in_trial=1`.
+    - If the presented options have no specific temporal or spatial order, leave this field empty or assign the same index to all options, e.g., `index_in_trial=1`.
   - categories:
     - Context
     name: object_id
     type: string
     requirement: optional
-    description: An option is defined by a set of features. This variable is used to identify each time
-      the same features were used. For example, if the same white digit "3" is used as an option in the
-      Digit Span task, all those instances would have the same `object_id` although they would have different
-      `id`s (as they appeared at different times).
+    description: An option is defined by a set of features. This variable is used to identify each time the same features were used. For example, if the same white digit "3" is used as an option in the Digit Span task, all those instances would have the same `object_id` although they would have different `id`s (as they appeared at different times).
   - categories:
     - When
     name: onset
     type: float
     requirement: required
-    description: Duration between the start of the trial and the moment the option was displayed or activated,
-      in seconds.
+    description: Duration between the start of the trial and the moment the option was displayed or activated, in seconds.
     range: In seconds
   - categories:
     - When
     name: duration
     type: float
     requirement: required
-    description: How long the option was displayed or active in seconds, starting from the `onset`, in
-      seconds.
+    description: How long the option was displayed or active in seconds, starting from the `onset`, in seconds.
     range: In seconds
   - categories:
     - Where
@@ -1005,9 +761,7 @@ tables:
     requirement: optional
     description: X coordinates of the option component on the screen in pixels.
     notes:
-    - In BDM, the preferred position is the center of the object. However, specific implementations of
-      the tasks may use other locations such as the top-left corner. If this is the case, it should be
-      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+    - In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
   - categories:
     - Where
     name: y_screen
@@ -1019,72 +773,56 @@ tables:
     name: x_viewport
     type: float
     requirement: optional
-    description: X coordinates of the option component on the screen expressed as a fraction of the screen
-      width.
+    description: X coordinates of the option component on the screen expressed as a fraction of the screen width.
     range: 0 to 1 (inclusive).
   - categories:
     - Where
     name: y_viewport
     type: float
     requirement: optional
-    description: Y coordinates of the option component on the screen expressed as a fraction of the screen
-      height.
+    description: Y coordinates of the option component on the screen expressed as a fraction of the screen height.
     range: 0 to 1 (inclusive).
   - categories:
     - What
     name: description
     type: string
     requirement: required
-    description: A human readable, compact description of the main aspects of the option. The description
-      for a given option depends on the task but follows a specific template for a given task. Because
-      of this, it looks like the option description could be parsed---however, this is not the intention;
-      structured, parsed data will be available in other fields; description is for human readability
-      and facilitates the understanding of the data.
+    description: A human readable, compact description of the main aspects of the option. The description for a given option depends on the task but follows a specific template for a given task. Because of this, it looks like the option description could be parsed---however, this is not the intention; structured, parsed data will be available in other fields; description is for human readability and facilitates the understanding of the data.
   - categories:
     - What
     name: value
     type: float
     requirement: optional
-    description: A numeric value associated with a particular response option; typically indicating the
-      "worth" of a response (e.g., `value=1` for the correct response).
+    description: A numeric value associated with a particular response option; typically indicating the "worth" of a response (e.g., `value=1` for the correct response).
   - categories:
     - What
     name: source
     type: string
     requirement: required
-    description: Refers to the specific generator or set from which the option originates. Options sharing
-      the same source have the same data structure and can be thus collectively described in a table named
-      after `option_source` (e.g., "digit1to9").
+    description: Refers to the specific generator or set from which the option originates. Options sharing the same source have the same data structure and can be thus collectively described in a table named after `option_source` (e.g., "digit1to9").
     notes:
-    - The `option_source` specifies the table or file that provides complete details about the option.
-      For instance, `option_source=digit1to9` indicates a source containing information on digits 1 to
-      9.
+    - The `option_source` specifies the table or file that provides complete details about the option. For instance, `option_source=digit1to9` indicates a source containing information on digits 1 to 9.
   - categories:
     - What
     name: source_type
     type: enum
     requirement: optional
-    description: An option is typically created using a particular procedure/algorithm or is sampled from
-      a particular set. This variable indicates which of these two applies for the current option.
-    range: '- `set`: option is sampled from a fixed set of options. - `generator`: option is created using
-      a procedure/algorithm.'
+    description: An option is typically created using a particular procedure/algorithm or is sampled from a particular set. This variable indicates which of these two applies for the current option.
+    range: '- `set`: option is sampled from a fixed set of options. - `generator`: option is created using a procedure/algorithm.'
   - categories:
     - What
     name: index_in_source
     type: integer
     requirement: optional
-    description: When a option is picked from a particular set (e.g., `digits1to9`), this index refers
-      to the index within that set.
+    description: When a option is picked from a particular set (e.g., `digits1to9`), this index refers to the index within that set.
   - categories:
     - How
     name: animation
     type: string
     requirement: optional
-    description: Describes the animation used to display a specific option in a human-readable format.
-      For example, "fadeIn 3s ease-in-out" indicates a 3-second fade-in animation.
+    description: Describes the animation used to display a specific option in a human-readable format. For example, "fadeIn 3s ease-in-out" indicates a 3-second fade-in animation.
     notes:
-    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common
-      animations (e.g., "3s linear slide-in").
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for common animations (e.g., "3s linear slide-in").
 - name: Input
   label: Input
   description: A detailed log of all inputs and clicks recorded during the trial.
@@ -1094,36 +832,28 @@ tables:
     name: input_id
     type: PRIMARY KEY
     requirement: required
-    description: Primary key; each input or click has its own identifier value that is unique within the
-      table.
+    description: Primary key; each input or click has its own identifier value that is unique within the table.
   - categories:
     - Context
     name: response_id
     type: id
     requirement: required
-    description: Indexing all the clicks that occurred within a given trial; ranging from 1 to `input_count`
-      in the corresponding `Response` table.
+    description: Indexing all the clicks that occurred within a given trial; ranging from 1 to `input_count` in the corresponding `Response` table.
   - categories:
     - Context
     name: response_element_index
     type: index
     requirement: optional
-    description: Indicates which of the clicks is used and in what order to form the actual response in
-      the response table when `response_structure` is "sequence" or "set".
+    description: Indicates which of the clicks is used and in what order to form the actual response in the response table when `response_structure` is "sequence" or "set".
     range: 1 to `input_count` in the corresponding row of the `Response` table.
     notes:
-    - This needs to be here rather than in `Option` table, because the same option can be clicked multiple
-      times and either serve or not for the response depending on the order of the clicks. For example,
-      in the Digit Span test we could have the response of "3;5;7" on a particular trial. This might correspond
-      to > - `option.description` = ["3", "4", "delete", "delete", "3", "5", "7", "enter"] > - `click.response_element_index`
-      = [NA, NA, NA, NA, 1, 2, 3, NA]
+    - This needs to be here rather than in `Option` table, because the same option can be clicked multiple times and either serve or not for the response depending on the order of the clicks. For example, in the Digit Span test we could have the response of "3;5;7" on a particular trial. This might correspond to > - `option.description` = ["3", "4", "delete", "delete", "3", "5", "7", "enter"] > - `click.response_element_index` = [NA, NA, NA, NA, 1, 2, 3, NA]
   - categories:
     - When
     name: onset
     type: float
     requirement: required
-    description: Duration between the start of the trial and the moment the mouse button press occured,
-      in seconds.
+    description: Duration between the start of the trial and the moment the mouse button press occured, in seconds.
     range: seconds
   - categories:
     - When
@@ -1151,16 +881,14 @@ tables:
     name: x_viewport
     type: float
     requirement: optional
-    description: X coordinates of the click relative to the left edge of the screen expressed as a fraction
-      of the screen width.
+    description: X coordinates of the click relative to the left edge of the screen expressed as a fraction of the screen width.
     range: 0 to 1 (inclusive).
   - categories:
     - Where
     name: y_viewport
     type: float
     requirement: optional
-    description: Y coordinates of the click relative to the top edge of the screen expressed as a fraction
-      of the screen height.
+    description: Y coordinates of the click relative to the top edge of the screen expressed as a fraction of the screen height.
     range: 0 to 1 (inclusive).
   - categories:
     - What
@@ -1185,8 +913,7 @@ tables:
     name: object_state
     type: string
     requirement: optional
-    description: Describes the state the object was in *before* it was clicked on. The meaning of "state"
-      depends on the particular task (e.g., "new empty").
+    description: Describes the state the object was in *before* it was clicked on. The meaning of "state" depends on the particular task (e.g., "new empty").
   - categories:
     - What
     name: option_id
@@ -1217,12 +944,10 @@ tables:
     name: index
     type: index
     requirement: required
-    description: A 1-based index indicating the stacking order of stimulus components. A stimulus component
-      with a higher `index` is displayed on top of those with lower values, similar to CSS z-index property.
+    description: A 1-based index indicating the stacking order of stimulus components. A stimulus component with a higher `index` is displayed on top of those with lower values, similar to CSS z-index property.
     range: 1-based indices
     notes:
-    - If the presented options have no specific temporal or spatial order, leave this field empty or assign
-      the same index to all options, e.g., `index=1`.
+    - If the presented options have no specific temporal or spatial order, leave this field empty or assign the same index to all options, e.g., `index=1`.
   - categories:
     - Where
     name: x_screen
@@ -1231,9 +956,7 @@ tables:
     description: X coordinates of the stimulus component relative to the left edge of the screen in pixels.
     range: pixels
     notes:
-    - In BDM, the preferred position is the center of the object. However, specific implementations of
-      the tasks may use other locations such as the top-left corner. If this is the case, it should be
-      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+    - In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
   - categories:
     - Where
     name: y_screen
@@ -1246,16 +969,14 @@ tables:
     name: x_viewport
     type: float
     requirement: optional
-    description: X coordinates of the stimulus component relative to the left edge of the screen expressed
-      as a fraction of the screen width.
+    description: X coordinates of the stimulus component relative to the left edge of the screen expressed as a fraction of the screen width.
     range: 0 to 1 (inclusive)
   - categories:
     - Where
     name: y_viewport
     type: float
     requirement: optional
-    description: Y coordinates of the stimulus component relative to the top edge of the screen expressed
-      as a fraction of the screen height.
+    description: Y coordinates of the stimulus component relative to the top edge of the screen expressed as a fraction of the screen height.
     range: 0 to 1 (inclusive)
   - categories:
     - What
@@ -1281,11 +1002,9 @@ tables:
     type: enum
     requirement: optional
     description: How the symbols are laid out.
-    range: '- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` -
-      `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`'
+    range: '- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` - `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`'
     notes:
-    - If none of the predefined layouts apply, leave this field empty or use a custom human-readable label.
-      Make sure custom labels are clearly defined in the codebook.
+    - If none of the predefined layouts apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook.
   - categories:
     - What
     name: color_name
@@ -1293,15 +1012,13 @@ tables:
     requirement: optional
     description: The human-readable name of the component color, e.g., `red`.
     notes:
-    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors
-      (e.g., "lightgray").
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors (e.g., "lightgray").
   - categories:
     - What
     name: color_hex
     type: string
     requirement: optional
-    description: 'The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional
-      alpha channel for transparency.'
+    description: 'The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional alpha channel for transparency.'
     range: '#000000 to #FFFFFF'
   - categories:
     - What
@@ -1309,11 +1026,9 @@ tables:
     type: enum
     requirement: optional
     description: Indicates the symbol orientation.
-    range: '- `north`: bottom to top. - `north_east` - `east`: left to right. - `south_east` - `south`:
-      top to bottom. - `south_west` - `west`: right to left - `north_west` - `free`: no specific orientation.'
+    range: '- `north`: bottom to top. - `north_east` - `east`: left to right. - `south_east` - `south`: top to bottom. - `south_west` - `west`: right to left - `north_west` - `free`: no specific orientation.'
     notes:
-    - If none of the predefined orientations apply, leave this field empty or use a custom human-readable
-      label. Make sure custom labels are clearly defined in the codebook.
+    - If none of the predefined orientations apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook.
 - name: OptionComponent
   label: OptionComponent
   description: Options can comprise multiple components. This table describes each component of an option.
@@ -1323,9 +1038,7 @@ tables:
     name: index
     type: index
     requirement: required
-    description: A 1-based index differentiating each part and indicating the stacking order of them.
-      An option component with a higher `index` is displayed on top of those with lower values, similar
-      to CSS z-index property.
+    description: A 1-based index differentiating each part and indicating the stacking order of them. An option component with a higher `index` is displayed on top of those with lower values, similar to CSS z-index property.
     range: 1-based indices
   - categories:
     - Key
@@ -1348,9 +1061,7 @@ tables:
     description: X coordinates of the option component relative to the left edge of the screen in pixels.
     range: pixels
     notes:
-    - In BDM, the preferred position is the center of the object. However, specific implementations of
-      the tasks may use other locations such as the top-left corner. If this is the case, it should be
-      explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
+    - In BDM, the preferred position is the center of the object. However, specific implementations of the tasks may use other locations such as the top-left corner. If this is the case, it should be explicitly stated in the [codebook](/spec/general/2-dataset-cards.qmd).
   - categories:
     - Where
     name: y_screen
@@ -1363,16 +1074,14 @@ tables:
     name: x_viewport
     type: float
     requirement: optional
-    description: X coordinates of the option component relative to the left edge of the screen expressed
-      as a fraction of the screen width.
+    description: X coordinates of the option component relative to the left edge of the screen expressed as a fraction of the screen width.
     range: 0 to 1 (inclusive)
   - categories:
     - Where
     name: y_viewport
     type: float
     requirement: optional
-    description: Y coordinates of the option component relative to the top edge of the screen expressed
-      as a fraction of the screen height.
+    description: Y coordinates of the option component relative to the top edge of the screen expressed as a fraction of the screen height.
     range: 0 to 1 (inclusive)
   - categories:
     - What
@@ -1398,11 +1107,9 @@ tables:
     type: enum
     requirement: optional
     description: How the symbols are laid out.
-    range: '- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` -
-      `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`'
+    range: '- `vertical`: along the Y axis. - `horizontal`: along the X axis. - `diagonal_top_left` - `diagonal_top_right` - `square` - `ring` - `cross` - `two_columns`'
     notes:
-    - If none of the predefined layouts apply, leave this field empty or use a custom human-readable label.
-      Make sure custom labels are clearly defined in the codebook.
+    - If none of the predefined layouts apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook.
   - categories:
     - What
     name: color_name
@@ -1410,15 +1117,13 @@ tables:
     requirement: optional
     description: The human-readable name of the component color, e.g., `red`.
     notes:
-    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors
-      (e.g., "lightgray").
+    - To maintain clarity and consistency, BDM recommends using CSS-style naming conventions for colors (e.g., "lightgray").
   - categories:
     - What
     name: color_hex
     type: string
     requirement: optional
-    description: 'The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional
-      alpha channel for transparency.'
+    description: 'The hexadecimal RGB color code of the component (e.g., #FF0000 for red) with optional alpha channel for transparency.'
     range: '#000000(00) to #FFFFFF(FF)'
   - categories:
     - What
@@ -1427,53 +1132,43 @@ tables:
     requirement: optional
     description: Indicates the symbol orientation.
     notes:
-    - If none of the predefined orientations apply, leave this field empty or use a custom human-readable
-      label. Make sure custom labels are clearly defined in the codebook.
+    - If none of the predefined orientations apply, leave this field empty or use a custom human-readable label. Make sure custom labels are clearly defined in the codebook.
 - name: Instrument
   label: Instrument
   description: Describes the instrument used for data acquisition.
   notes:
-  - this table includes information about specific parameterizations of the instruments (i.e., timelines).
-    For example, parameters for the software that executes the presentation of the stimuli and records
-    key presses.
+  - this table includes information about specific parameterizations of the instruments (i.e., timelines). For example, parameters for the software that executes the presentation of the stimuli and records key presses.
   fields:
   - categories:
     - Identifier
     name: instrument_id
     type: string
     requirement: required
-    description: Unique identifier of an instrument. It can be formed by combining name and version (e.g.,
-      "DS_v2024.01").
+    description: Unique identifier of an instrument. It can be formed by combining name and version (e.g., "DS_v2024.01").
   - categories:
     - Identifier
     name: timeline_id
     type: string
     requirement: required
-    description: Identifier for a timeline. Timeline is a variant of an instrument with specific parametrization,
-      for the whole experiment or for multiple block of trials (e.g., "DS_FORWARD" and "DS_BACKWARD" for
-      digit span task). Timelines are configurations that specify instrument parameters.
+    description: Identifier for a timeline. Timeline is a variant of an instrument with specific parametrization, for the whole experiment or for multiple block of trials (e.g., "DS_FORWARD" and "DS_BACKWARD" for digit span task). Timelines are configurations that specify instrument parameters.
   - categories:
     - Identifier
     name: block_id
     type: string
     requirement: required
-    description: Specific parameterization of the instrument for a single block of trials (e.g., "DS_FORWARD_PRACTICE"
-      and "DS_FOWARD_TEST"). Block-level parameters override timeline-level parameters.
+    description: Specific parameterization of the instrument for a single block of trials (e.g., "DS_FORWARD_PRACTICE" and "DS_FOWARD_TEST"). Block-level parameters override timeline-level parameters.
   - categories:
     - What
     name: name
     type: string
     requirement: required
-    description: Name of the toolkit (scene, code, or configuration) that is used to collect the data,
-      e.g., "DS" for a software that runs digit span task in forward OR backward order. The specific parameterization
-      of the instrument is defined by the "Timeline" (e.g., a variant of instrument called "DS_FORWARD").
+    description: Name of the toolkit (scene, code, or configuration) that is used to collect the data, e.g., "DS" for a software that runs digit span task in forward OR backward order. The specific parameterization of the instrument is defined by the "Timeline" (e.g., a variant of instrument called "DS_FORWARD").
   - categories:
     - What
     name: version
     type: string
     requirement: optional
-    description: Refers to the specific version/build of a particular instrument. We will use a calendar
-      based versioning system ([calver.org](https://calver.org/); e.g., "v2024.01").
+    description: Refers to the specific version/build of a particular instrument. We will use a calendar based versioning system ([calver.org](https://calver.org/); e.g., "v2024.01").
   - categories:
     - What
     name: description
@@ -1485,7 +1180,6 @@ tables:
     name: link
     type: url
     requirement: optional
-    description: External link, if any, the provides more information about the instrument, e.g., on Cognitive
-      Atlas.
+    description: External link, if any, the provides more information about the instrument, e.g., on Cognitive Atlas.
     notes:
     - Permanent links, e.g., DOIs, are preferred over particular websites.

--- a/trial/scripts/generate.py
+++ b/trial/scripts/generate.py
@@ -1,0 +1,63 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyyaml"]
+# ///
+"""Generate published artifacts for the trial schema from field-definitions.yaml.
+
+The trial model is multi-table, so (unlike the single-object dataset/catalog schemas) its
+render contract is a `tables` document. This generates:
+
+  - field-definitions.json  — the render artifact consumed by behaverse/data-model (summary
+                              tables) and by the docs site. This is what BDM fetches.
+
+Planned (follow-up, not yet emitted): schema.json (per-table JSON Schema for validation) and
+context.jsonld. See trial/README.md.
+
+Usage:
+    uv run scripts/generate.py
+    uv run scripts/generate.py --check   # dry run; exit 1 if field-definitions.json is stale
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml  # type: ignore
+
+TRIAL_DIR = Path(__file__).parent.parent
+
+
+def build_field_definitions(src: dict) -> dict:
+    meta = src["schema_metadata"]
+    return {
+        "schema": "trial",
+        "version": meta["version"],
+        "namespace": meta["namespace"],
+        "description": meta["description"],
+        "tables": src["tables"],
+    }
+
+
+def main() -> None:
+    check = "--check" in sys.argv
+    src = yaml.safe_load((TRIAL_DIR / "field-definitions.yaml").read_text())
+    out = build_field_definitions(src)
+    rendered = json.dumps(out, indent=2, ensure_ascii=False) + "\n"
+
+    target = TRIAL_DIR / "field-definitions.json"
+    if check:
+        current = target.read_text() if target.exists() else ""
+        if current != rendered:
+            print(f"stale: {target} would change — run without --check")
+            sys.exit(1)
+        print(f"up to date: {target}")
+        return
+
+    target.write_text(rendered)
+    n_fields = sum(len(t["fields"]) for t in out["tables"])
+    print(f"✓ generated {target} — {len(out['tables'])} tables, {n_fields} fields")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stands up two new schemas so **behaverse/data-model** can document them *by reference* (fetch-and-render) instead of generating from a Google Sheet. Part of the BDM "reference-only umbrella" redesign.

## `trial/` — the BDM trial tables (relocated from data-model)
- `field-definitions.yaml` (source) + generated `field-definitions.json` — **7 tables, 161 fields** (Response, Stimulus, Option, Input, StimulusComponent, OptionComponent, Instrument).
- Seeded from data-model's gsheet export; Quarto/Bootstrap markup stripped (table refs → plain backticked names), fields re-keyed to the repo convention (`variable_name`→`name`, `data_type`→`type`, `required`→`requirement`).
- `scripts/generate.py` (`--check` for CI), `README.md`, `CHANGELOG.md`.
- Moved **as-is** — known issues filed as follow-ups (see below).

## `event/` — Event envelope + canonical `bdm:` vocabulary
- `field-definitions.yaml` (source) + `field-definitions.json` — **11 envelope fields + 24 verbs / 15 object types / 5 actor types**.
- `schema.json` (Draft 2020-12) + `context.jsonld` + `examples/` relocated from the questionnaire project's `schemas/events` v26.0605, **canonicalized `events`→`event` (singular)**, `$id`/namespace → `…/schemas/event/v26.0608/…`.
- Realizes BDM deviations **D4** (vocabulary), **D5** (`agent`→`actor`, applied), **D6** (scoping hierarchy).

## Render contract (what data-model fetches)
Each schema publishes `field-definitions.json` with per-field `name / type / requirement / categories / description / range? / notes?`. data-model renders a summary table and links out to `behaverse.org/schemas/<name>` for the full reference (hybrid doc surface). Proven end-to-end locally (Quarto render of trial + event pages).

## Verify
```bash
uv run trial/scripts/generate.py --check
uv run event/scripts/generate.py --check
```

## Follow-ups (not in this PR)
- `trial`: D1 (`stimulus_id` typing), D3 (`session_id`/`session_index` + UUID), D5 already applied in `event`.
- `trial`: `schema.json` + `context.jsonld` (validation/JSON-LD).
- `event`: relocate the ~50 `bdm:*` extension-key contracts; tighten per-verb `result`.
- Repo-wide: LICENSE file + validation CI.

## Deploy note
data-model pins these via `schemas.lock`; it currently builds against a local clone (`--local-dir`). Once this merges **and the schemas site deploys** the versioned `field-definitions.json` URLs, data-model can drop `--local-dir` and pin content hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)