### PR TITLE
deploy-docs (gh-pages): publish vocabulary/

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout schemas and scripts from main branch
         run: |
           git fetch origin main
-          git checkout origin/main -- bcsv/ catalog/ dataset/ studyflow/ trial/ event/
+          git checkout origin/main -- bcsv/ catalog/ dataset/ studyflow/ trial/ event/ vocabulary/
       
       - name: Setup Python with uv
         uses: astral-sh/setup-uv@v8.2.0  # no moving `v8` major tag is published; pin the full version
@@ -53,7 +53,7 @@ jobs:
       
       - name: Copy raw schemas to static directory
         run: |
-          for schema in bcsv catalog dataset studyflow trial event; do
+          for schema in bcsv catalog dataset studyflow trial event vocabulary; do
             cp -r $schema docs/static/
           done
       


### PR DESCRIPTION
Companion to #12 — the gh-pages copy of the deploy workflow gets the same two lines (`vocabulary/` in the main-checkout list and the static-copy loop), keeping the two build jobs in sync as the workflow header requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)