### PR TITLE
ci: gate deploy on validation; guard conformance, JSON-LD, and enum consistency

### DIFF
--- a/.github/workflows/build-deploy-pages.yml
+++ b/.github/workflows/build-deploy-pages.yml
@@ -41,7 +41,15 @@ jobs:
 
       - name: Install Node dependencies
         working-directory: ./docs
-        run: npm install
+        # npm ci pins the build to gh-pages's docs/package-lock.json (reproducible);
+        # fall back to npm install only if the lockfile is ever removed.
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            echo "::warning::docs/package-lock.json missing on gh-pages — unpinned npm install fallback"
+            npm install
+          fi
 
       - name: Copy raw schemas to static directory
         run: |

--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -1,8 +1,10 @@
 name: Deploy docs (main)
 
-# Pushing to `main` redeploys the docs site. The actual build+deploy lives in the
-# reusable workflow build-deploy-pages.yml (single source of truth); gh-pages's
-# deploy-docs.yml calls the same reusable workflow, so there is no duplicated build job.
+# Pushing to `main` validates the schemas and, only if validation passes, redeploys the
+# docs site — a push that breaks a schema or leaves generated artifacts stale can no
+# longer go live. The build+deploy lives in the reusable workflow build-deploy-pages.yml
+# (single source of truth); gh-pages's deploy-docs.yml calls the same reusable workflow,
+# so there is no duplicated build job.
 
 on:
   push:
@@ -15,5 +17,9 @@ permissions:
   id-token: write
 
 jobs:
+  validate:
+    uses: ./.github/workflows/validate-schemas.yml
+
   deploy:
+    needs: validate
     uses: ./.github/workflows/build-deploy-pages.yml

--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -1,17 +1,23 @@
 name: Validate schemas
 
-# Guards the source-of-truth contract on `main` (deploy lives in deploy-on-main.yml):
+# Guards the source-of-truth contract on `main` (deploy lives in deploy-on-main.yml,
+# which CALLS this workflow and only deploys if it passes):
 #   1. every LinkML source (catalog/dataset/trial/event/studyflow) is metamodel-valid;
 #   2. generated artifacts (schema.json / context.jsonld / field-definitions.json) are in
 #      sync with their LinkML source — i.e. `scripts/generate.py` regeneration is a no-op;
 #   3. the vocabulary SKOS artifact (terms.jsonld) is in sync with terms.yaml;
-#   4. every schema.json is well-formed and its bundled examples validate.
+#   4. the bcsv conformance fixtures are in sync with their generator;
+#   5. every schema.json is well-formed; examples, conformance fixtures, JSON-LD
+#      contexts (pyld expansion, no network), and LinkML enum usage all validate.
+#
+# No `push: main` trigger: pushes to main run this via deploy-on-main.yml's `validate`
+# job (workflow_call), so it is not duplicated.
 
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   validate:
@@ -42,5 +48,8 @@ jobs:
       - name: Vocabulary terms.jsonld is in sync with terms.yaml
         run: python vocabulary/scripts/generate.py --check
 
-      - name: Schemas are well-formed and examples validate
+      - name: bcsv conformance fixtures are in sync with their generator
+        run: python bcsv/conformance/_generate.py --check
+
+      - name: Schemas, examples, conformance fixtures, and JSON-LD contexts validate
         run: python scripts/validate_schemas.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,25 +43,35 @@ generated file drifts from its source.
    [`VERSIONING.md`](VERSIONING.md).
 5. **Validate locally** (this is exactly what CI runs):
    ```bash
-   pip install linkml jsonschema pyyaml
+   pip install -r requirements-dev.txt
    linkml-lint --validate --ignore-warnings <schema>/schema.linkml.yaml  # metamodel-valid source
    python scripts/generate.py --check              # drift guard (exit 1 if any would change)
    python vocabulary/scripts/generate.py --check   # vocabulary drift guard
-   python scripts/validate_schemas.py              # well-formedness + examples
+   python bcsv/conformance/_generate.py --check    # conformance-fixture drift guard
+   python scripts/validate_schemas.py              # well-formedness + examples + conformance
+                                                   # fixtures + JSON-LD expansion + LinkML enum use
    ```
 
 ## CI & deployment
 
 Two workflows guard and publish `main`:
 
-- **`/.github/workflows/validate-schemas.yml`** (every PR and push to `main`):
-  1. **Drift guard** — metamodel-validates the LinkML sources, then runs
-     `scripts/generate.py --check` and `vocabulary/scripts/generate.py --check`; fails if
-     any generated file is out of sync with its source.
+- **`/.github/workflows/validate-schemas.yml`** (every PR; called by deploy-on-main.yml
+  on every push to `main`):
+  1. **Drift guards** — metamodel-validates the LinkML sources, then runs
+     `scripts/generate.py --check`, `vocabulary/scripts/generate.py --check`, and
+     `bcsv/conformance/_generate.py --check`; fails if any generated file is out of
+     sync with its source.
   2. **Validation** — `scripts/validate_schemas.py` checks every `schema.json` is
-     well-formed (Draft-07 or 2020-12, per its `$schema`) and that its `examples/*` validate.
-- **`/.github/workflows/deploy-on-main.yml`** (every push to `main`): redeploys the docs
-  site. **So merging to `main` publishes automatically** — no manual deploy needed.
+     well-formed (draft per its `$schema`), that its `examples/*` validate, that the
+     bcsv conformance fixtures agree with `bcsv/schema.json` and their `expected.json`,
+     that every `context.jsonld` (+ `vocabulary/terms.jsonld`) expands cleanly with
+     pyld (remote fetches forbidden), and that LinkML enum-ranged slots only use
+     permissible values in examples and `ifabsent` defaults.
+- **`/.github/workflows/deploy-on-main.yml`** (every push to `main`): runs the
+  validation workflow above and — **only if it passes** — redeploys the docs site.
+  So merging to `main` publishes automatically, and a push that breaks a schema or
+  leaves stale artifacts does not deploy.
 
 The Docusaurus site itself lives on the **`gh-pages`** branch (its `docs/` and
 `scripts/generate_docs.py`). The build+deploy is defined **once**, in the reusable workflow

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Raw experimental events — an xAPI-style envelope (actor / verb / object) carry
 ### vocabulary
 Cross-cutting controlled terminology (SKOS concept schemes + concepts): general terms, demographics, and the suffix conventions used in variable names — the terms no single schema owns.
 
-- **Version**: v26.0611  ·  **Source**: `vocabulary/terms.yaml` (SKOS; not LinkML)
+- **Version**: v26.0703  ·  **Source**: `vocabulary/terms.yaml` (SKOS; not LinkML)
 - **Namespace**: `https://behaverse.org/schemas/vocabulary`
 - **SKOS JSON-LD**: [`vocabulary/terms.jsonld`](vocabulary/terms.jsonld) · **Docs**: [`vocabulary/README.md`](vocabulary/README.md)
 

--- a/bcsv/conformance/_generate.py
+++ b/bcsv/conformance/_generate.py
@@ -13,7 +13,10 @@ contains exactly three files:
 
 Run from the schema repo root::
 
-    python bcsv/conformance/_generate.py
+    python bcsv/conformance/_generate.py            # (re)write the fixtures
+    python bcsv/conformance/_generate.py --check    # drift guard: exit 1 if the
+                                                    # committed fixtures differ from
+                                                    # what this script would write
 
 This overwrites existing fixtures with freshly-computed hashes. Don't edit
 the .csv / .json files by hand — edit this script and regenerate.
@@ -25,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -48,30 +52,35 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _write_fixture(fx: Fixture) -> None:
-    dir_path = CONFORMANCE_DIR / fx.kind / fx.name
-    dir_path.mkdir(parents=True, exist_ok=True)
-    # Clean any stale files left from previous runs.
-    for child in dir_path.iterdir():
-        child.unlink()
+def _render_fixture(fx: Fixture) -> dict[Path, str]:
+    """Render a fixture to {relative path: file content} without touching disk."""
+    dir_path = Path(fx.kind) / fx.name
+    files: dict[Path, str] = {}
 
     if fx.csv is not None:
-        (dir_path / "data.csv").write_text(fx.csv, encoding="utf-8")
+        files[dir_path / "data.csv"] = fx.csv
 
     meta = dict(fx.metadata) if fx.metadata is not None else None
     if meta is not None and fx.add_hash:
         meta["file_hash"] = _sha256(fx.csv or "")
 
     if fx.invalid_metadata_text is not None:
-        (dir_path / "metadata.json").write_text(fx.invalid_metadata_text, encoding="utf-8")
+        files[dir_path / "metadata.json"] = fx.invalid_metadata_text
     elif meta is not None:
-        (dir_path / "metadata.json").write_text(
-            json.dumps(meta, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-        )
+        files[dir_path / "metadata.json"] = json.dumps(meta, indent=2, ensure_ascii=False) + "\n"
 
-    (dir_path / "expected.json").write_text(
-        json.dumps(fx.expected, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-    )
+    files[dir_path / "expected.json"] = json.dumps(fx.expected, indent=2, ensure_ascii=False) + "\n"
+    return files
+
+
+def _write_fixture(fx: Fixture) -> None:
+    dir_path = CONFORMANCE_DIR / fx.kind / fx.name
+    dir_path.mkdir(parents=True, exist_ok=True)
+    # Clean any stale files left from previous runs.
+    for child in dir_path.iterdir():
+        child.unlink()
+    for rel, content in _render_fixture(fx).items():
+        (CONFORMANCE_DIR / rel).write_text(content, encoding="utf-8")
 
 
 def _meta(columns: list[dict], **extra: Any) -> dict:
@@ -356,11 +365,47 @@ NEGATIVE: list[Fixture] = [
 ]
 
 
-def main() -> None:
+def _check() -> int:
+    """Compare the committed fixtures against a fresh render; exit 1 on drift."""
+    expected_files: dict[Path, str] = {}
+    for fx in POSITIVE + NEGATIVE:
+        expected_files.update(_render_fixture(fx))
+
+    problems: list[str] = []
+    for rel, content in sorted(expected_files.items()):
+        path = CONFORMANCE_DIR / rel
+        if not path.exists():
+            problems.append(f"missing: {rel}")
+        elif path.read_text(encoding="utf-8") != content:
+            problems.append(f"stale: {rel}")
+
+    # Files on disk that no fixture would write (leftovers from removed fixtures).
+    for kind in ("positive", "negative"):
+        base = CONFORMANCE_DIR / kind
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.is_file() and path.relative_to(CONFORMANCE_DIR) not in expected_files:
+                problems.append(f"extra: {path.relative_to(CONFORMANCE_DIR)}")
+
+    if problems:
+        print("conformance fixtures drift from _generate.py:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print("run `python bcsv/conformance/_generate.py` to regenerate", file=sys.stderr)
+        return 1
+    print(f"conformance fixtures up to date ({len(POSITIVE)} positive + {len(NEGATIVE)} negative)")
+    return 0
+
+
+def main() -> int:
+    if "--check" in sys.argv[1:]:
+        return _check()
     for fx in POSITIVE + NEGATIVE:
         _write_fixture(fx)
     print(f"Wrote {len(POSITIVE)} positive + {len(NEGATIVE)} negative fixtures to {CONFORMANCE_DIR}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ linkml==1.8.5
 linkml-runtime==1.8.3
 jsonschema>=4.21
 PyYAML>=6.0
+pyld>=2.0.3

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -1,20 +1,35 @@
 #!/usr/bin/env python3
 """Validate the JSON-Schema-based schemas and their bundled examples.
 
-For each schema directory: assert `schema.json` is a well-formed schema (Draft-07 or
-2020-12, chosen from its `$schema`), then validate every `examples/*.json` against it
-(trial has no examples, so only well-formedness is checked). Custom annotation keywords
-(e.g. `equivalentProperty`) are ignored by the validator, as are string formats
-(uri/date/email) — we check structure, matching the `ajv --strict=false` policy.
+Four check families, all run by CI (validate-schemas.yml):
 
-Exit non-zero on the first problem. studyflow is LinkML-based and is checked by
-its own toolchain, so it is not included here.
+1. Schemas + examples — assert every `schema.json` is a well-formed schema (draft
+   chosen from its `$schema`), then validate every `examples/*.json` against it
+   (trial has no examples, so only well-formedness is checked). Custom annotation
+   keywords (e.g. `equivalentProperty`) are ignored by the validator, as are string
+   formats (uri/date/email) — we check structure, matching `ajv --strict=false`.
+2. bcsv conformance fixtures — every positive fixture's metadata.json must validate
+   against bcsv/schema.json; negative fixtures' metadata must match what their
+   expected.json implies (schema-invalid for SCHEMA_VIOLATION-class fixtures,
+   schema-valid for data-stage fixtures); embedded file_hash values must (mis)match
+   data.csv as the fixture intends.
+3. JSON-LD contexts — every context.jsonld (and vocabulary/terms.jsonld) must expand
+   cleanly with pyld, with remote fetches forbidden; each example must survive
+   expansion against its schema's local context.
+4. LinkML enum consistency — on every enum-ranged slot in */schema.linkml.yaml, the
+   slot's examples and `ifabsent: string(...)` default must be permissible values
+   (the metamodel lint does not enforce either).
+
+Exit non-zero listing every problem found. studyflow has no schema.json (LinkML,
+consumed directly) so only checks 4 covers it.
 
 Usage:  python scripts/validate_schemas.py
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -22,6 +37,7 @@ import jsonschema
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMAS = ["bcsv", "catalog", "dataset", "trial", "event"]
+CONTEXT_SCHEMAS = ["bcsv", "catalog", "dataset", "event"]  # trial ships no context.jsonld
 
 
 def _validator_cls(schema: dict):
@@ -32,6 +48,123 @@ def _validator_cls(schema: dict):
     if "2019-09" in s:
         return jsonschema.Draft201909Validator
     return jsonschema.Draft7Validator
+
+
+def check_bcsv_conformance(failures: list[str]) -> None:
+    """Assert the conformance fixtures agree with bcsv/schema.json and their own expected.json."""
+    schema = json.loads((ROOT / "bcsv" / "schema.json").read_text())
+    validator = _validator_cls(schema)(schema)
+    conf = ROOT / "bcsv" / "conformance"
+
+    for fixture in sorted(p for kind in ("positive", "negative") for p in (conf / kind).iterdir() if p.is_dir()):
+        rel = fixture.relative_to(ROOT)
+        expected_path = fixture / "expected.json"
+        if not expected_path.exists():
+            failures.append(f"{rel}: missing expected.json")
+            continue
+        expected = json.loads(expected_path.read_text())
+        codes = {e["code"] for e in expected.get("errors", [])}
+        check_schema = expected.get("validate_with", {}).get("check_schema", True)
+
+        meta_path = fixture / "metadata.json"
+        meta = None
+        if meta_path.exists():
+            try:
+                meta = json.loads(meta_path.read_text())
+            except json.JSONDecodeError:
+                if "METADATA_INVALID_JSON" not in codes:
+                    failures.append(f"{rel}: metadata.json is unparseable but expected.json "
+                                    f"does not declare METADATA_INVALID_JSON")
+                continue
+        if "METADATA_INVALID_JSON" in codes:
+            failures.append(f"{rel}: expected METADATA_INVALID_JSON but metadata.json parsed cleanly")
+            continue
+        if meta is None:
+            continue  # fixture without metadata (nothing schema-level to assert)
+
+        schema_errors = list(validator.iter_errors(meta))
+        if "SCHEMA_VIOLATION" in codes:
+            if not schema_errors:
+                failures.append(f"{rel}: expected a schema violation but metadata.json validates")
+        elif check_schema and schema_errors:
+            failures.append(f"{rel}: metadata.json unexpectedly fails schema validation: "
+                            f"{schema_errors[0].message}")
+
+        # file_hash integrity: must match data.csv unless the fixture tests a mismatch.
+        data_path = fixture / "data.csv"
+        if "file_hash" in meta and data_path.exists():
+            actual = hashlib.sha256(data_path.read_bytes()).hexdigest()
+            if "HASH_MISMATCH" in codes:
+                if meta["file_hash"] == actual:
+                    failures.append(f"{rel}: HASH_MISMATCH fixture's file_hash matches data.csv")
+            elif meta["file_hash"] != actual:
+                failures.append(f"{rel}: file_hash does not match sha256(data.csv)")
+
+
+def check_jsonld_contexts(failures: list[str]) -> None:
+    """Expand every JSON-LD context (and each example against it) with pyld; no network."""
+    from pyld import jsonld
+
+    def _no_network(url, options=None):  # any remote fetch is a bug: contexts must be self-contained
+        raise jsonld.JsonLdError(f"remote context fetch attempted: {url}", "loadDocument")
+
+    jsonld.set_document_loader(_no_network)
+
+    for name in CONTEXT_SCHEMAS:
+        ctx_doc = json.loads((ROOT / name / "context.jsonld").read_text())
+        context = ctx_doc.get("@context")
+        if context is None:
+            failures.append(f"{name}/context.jsonld: no top-level @context key")
+            continue
+        probes = [(f"{name}/context.jsonld (minimal probe)", {"@context": context})]
+        for example in sorted((ROOT / name / "examples").glob("*.json")):
+            doc = json.loads(example.read_text())
+            doc["@context"] = context  # replace the remote URL with the local context
+            probes.append((str(example.relative_to(ROOT)), doc))
+        for label, doc in probes:
+            try:
+                expanded = jsonld.expand(doc)
+            except Exception as e:  # noqa: BLE001 — report any expansion failure
+                failures.append(f"{label}: JSON-LD expansion failed: {e}")
+                continue
+            if "examples" in label and not expanded:
+                failures.append(f"{label}: JSON-LD expansion produced no output "
+                                f"(no term in the example is mapped by the context)")
+        print(f"✓ {name}/context.jsonld expands (with {len(probes) - 1} example(s))")
+
+    terms = json.loads((ROOT / "vocabulary" / "terms.jsonld").read_text())
+    try:
+        if not jsonld.expand(terms):
+            failures.append("vocabulary/terms.jsonld: expansion produced no output")
+        else:
+            print("✓ vocabulary/terms.jsonld expands")
+    except Exception as e:  # noqa: BLE001
+        failures.append(f"vocabulary/terms.jsonld: JSON-LD expansion failed: {e}")
+
+
+def check_linkml_enum_consistency(failures: list[str]) -> None:
+    """Enum-ranged slots: examples and ifabsent defaults must be permissible values."""
+    from linkml_runtime.utils.schemaview import SchemaView
+
+    ifabsent_re = re.compile(r"^string\((.+)\)$")
+    for path in sorted(ROOT.glob("*/schema.linkml.yaml")):
+        sv = SchemaView(str(path))
+        enums = sv.all_enums()
+        rel = path.relative_to(ROOT)
+        for slot in sv.all_slots().values():
+            if slot.range not in enums:
+                continue
+            allowed = set(enums[slot.range].permissible_values.keys())
+            for ex in slot.examples or []:
+                val = getattr(ex, "value", None)
+                if val is not None and val not in allowed:
+                    failures.append(f"{rel}: slot '{slot.name}' example {val!r} is not a "
+                                    f"permissible value of enum {slot.range}")
+            if slot.ifabsent:
+                m = ifabsent_re.match(str(slot.ifabsent))
+                if m and m.group(1) not in allowed:
+                    failures.append(f"{rel}: slot '{slot.name}' default {m.group(1)!r} is not a "
+                                    f"permissible value of enum {slot.range}")
 
 
 def main() -> int:
@@ -65,13 +198,24 @@ def main() -> int:
             else:
                 print(f"✓ {rel} validates")
 
+    for check, label in [
+        (check_bcsv_conformance, "bcsv conformance fixtures agree with schema.json + expected.json"),
+        (check_jsonld_contexts, "JSON-LD contexts expand"),
+        (check_linkml_enum_consistency, "LinkML enum examples/defaults are permissible values"),
+    ]:
+        before = len(failures)
+        check(failures)
+        if len(failures) == before:
+            print(f"✓ {label}")
+
     if failures:
         print("\n✗ validation failed:", file=sys.stderr)
         for f in failures:
             print(f"  - {f}", file=sys.stderr)
         return 1
 
-    print("\n✓ all schemas well-formed and all examples valid")
+    print("\n✓ all schemas well-formed; examples, conformance fixtures, JSON-LD contexts, "
+          "and LinkML enum usage all valid")
     return 0
 
 

--- a/vocabulary/CHANGELOG.md
+++ b/vocabulary/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Vocabulary Changelog
+
+All notable changes to the vocabulary (SKOS concept schemes + concepts) will be
+documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project uses [Calendar Versioning](https://calver.org/) (YY.MMDD).
+
+## [26.0703] - 2026-07-03
+
+### Fixed
+- `terms.jsonld` was invalid JSON-LD: its context aliased both `schemes` and
+  `concepts` to `@graph`, which JSON-LD 1.1 processors reject as "colliding
+  keywords" — pyld could not expand the document at all. The two keys now map to
+  distinct containment properties (`bdm:schemes` / `bdm:concepts`, `@container:
+  @set`). **The JSON shape is unchanged** (consumers still read `schemes` and
+  `concepts` arrays); only the RDF expansion differs: scheme/concept nodes are now
+  linked from the vocabulary node via those properties instead of being asserted
+  as (unreachable, since expansion failed) default-graph nodes.
+- CI now expands `terms.jsonld` with pyld on every run, so this class of bug
+  cannot ship again.
+
+### Notes
+- This is the vocabulary's first CHANGELOG entry; earlier releases (`26.0611` and
+  before) predate it. See the git history of `terms.yaml` for prior changes.

--- a/vocabulary/scripts/generate.py
+++ b/vocabulary/scripts/generate.py
@@ -39,8 +39,12 @@ CONTEXT = {
     "data_type": "bdm:dataType",
     "range": "bdm:range",
     "status": "bdm:status",
-    "schemes": "@graph",
-    "concepts": "@graph",
+    # NOT two aliases of @graph: aliasing two terms to the same keyword is invalid
+    # JSON-LD ("colliding keywords"; pyld and other 1.1 processors reject it). Distinct
+    # containment properties keep the JSON shape identical for consumers and keep every
+    # scheme/concept node (with its @id/@type/SKOS properties) in the expanded graph.
+    "schemes": {"@id": "bdm:schemes", "@container": "@set"},
+    "concepts": {"@id": "bdm:concepts", "@container": "@set"},
 }
 
 

--- a/vocabulary/terms.jsonld
+++ b/vocabulary/terms.jsonld
@@ -13,13 +13,19 @@
     "data_type": "bdm:dataType",
     "range": "bdm:range",
     "status": "bdm:status",
-    "schemes": "@graph",
-    "concepts": "@graph"
+    "schemes": {
+      "@id": "bdm:schemes",
+      "@container": "@set"
+    },
+    "concepts": {
+      "@id": "bdm:concepts",
+      "@container": "@set"
+    }
   },
   "@id": "https://behaverse.org/schemas/vocabulary",
   "@type": "skos:ConceptScheme",
   "name": "Behaverse Vocabulary",
-  "version": "26.0611",
+  "version": "26.0703",
   "description": "Cross-cutting controlled terminology for behaverse data: general terms, demographics, and the suffix conventions used in variable names. Terms that one schema owns (e.g. trial table fields) live in that schema; this resource holds the terms no single schema owns.",
   "schemes": [
     {

--- a/vocabulary/terms.yaml
+++ b/vocabulary/terms.yaml
@@ -6,7 +6,7 @@
 
 vocabulary_metadata:
   name: Behaverse Vocabulary
-  version: '26.0611'
+  version: '26.0703'
   namespace: https://behaverse.org/schemas/vocabulary
   description: 'Cross-cutting controlled terminology for behaverse data: general terms, demographics,
     and the suffix conventions used in variable names. Terms that one schema owns (e.g. trial table fields)


### PR DESCRIPTION
Supersedes #15, which auto-closed when its stacked base branch (fix/schema-bug-batch) was deleted on merge of #14. Same commits, retargeted to main. Verified locally: linkml-lint, generate.py --check, vocabulary --check, validate_schemas.py, and bcsv conformance --check all pass; conflict-free merge onto main.