### PR TITLE
chore: versions/ immutability CI guard, stability contract, snapshot backfill

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -20,6 +20,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  # versions/ snapshots are immutable by policy (VERSIONING.md); this makes the policy
+  # mechanical: a PR may ADD snapshot files but never modify or delete one. Runs only on
+  # pull_request — on a workflow_call from deploy-on-main there is no base to diff against.
+  versions-immutable:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Snapshots are add-only
+        run: |
+          changed=$(git diff --name-status --diff-filter=MDRT \
+            "origin/${{ github.base_ref }}...HEAD" -- '*/versions/*')
+          if [ -n "$changed" ]; then
+            echo "::error::versions/ snapshots are immutable — add-only. Offending changes:"
+            echo "$changed"
+            exit 1
+          fi
+          echo "versions/ snapshots untouched or add-only"
+
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -98,6 +98,20 @@ that version in the changelog.
 Because CalVer does not telegraph breaking changes, the changelog's `### Breaking`
 callouts are the authoritative signal that a new version is incompatible.
 
+### What consumers may rely on
+
+- **Snapshot immutability is CI-enforced**: a pull request that modifies or deletes any
+  file under a `versions/` directory fails the `versions-immutable` check. Snapshots are
+  add-only.
+- **A pinned snapshot never changes meaning**: validation behavior against
+  `versions/v<V>/schema.json` is fixed forever.
+- **Unversioned URLs track `main`** and may change on any release, including
+  incompatibly; the family's `CHANGELOG.md` (its `### Breaking` headings in particular)
+  is the complete record of what changed between any two versions. There is no
+  compatibility contract between versions beyond what the changelog states.
+- **Releases are tagged** `<family>-v<VERSION>` in git, so every snapshot is navigable to
+  the exact commit that published it.
+
 ## Directory Structure
 
 A generated LinkML-sourced schema (`catalog`, `dataset`, `trial`, `event`) has:

--- a/catalog/versions/v25.1202/README.md
+++ b/catalog/versions/v25.1202/README.md
@@ -1,0 +1,8 @@
+# catalog v25.1202 — archived verbatim from the pre-rename release
+
+This release predates the `collection` → `catalog` rename (the family's first release,
+listed in [`../../CHANGELOG.md`](../../CHANGELOG.md)). The artifacts are archived exactly
+as published at the time — they self-identify as the "Behaverse Collection Schema" under
+the `…/schemas/collection` namespace, because that is what v25.1202 was. Backfilled from
+git history on 2026-07-29; the snapshot directory was never created when the release
+shipped.

--- a/catalog/versions/v25.1202/context.jsonld
+++ b/catalog/versions/v25.1202/context.jsonld
@@ -1,0 +1,60 @@
+{
+  "@context": {
+    "@vocab": "https://behaverse.org/schemas/collection#",
+    "behaverse": "https://behaverse.org/schemas/collection#",
+    "schema": "https://schema.org/",
+    "dc": "http://purl.org/dc/terms/",
+    "bids": "https://bids-specification.readthedocs.io/en/stable/",
+    "ddi": "https://ddialliance.org/Specification/DDI-Lifecycle/3.3/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "@type": "https://schema.org/Collection",
+    "name": {
+      "@id": "https://schema.org/name",
+      "@type": "xsd:string"
+    },
+    "pretty_name": {
+      "@id": "https://schema.org/name",
+      "@type": "xsd:string"
+    },
+    "description": {
+      "@id": "https://schema.org/description",
+      "@type": "xsd:string"
+    },
+    "keywords": {
+      "@id": "https://schema.org/keywords",
+      "@container": "@set"
+    },
+    "inclusion_criteria": {
+      "@id": "behaverse:inclusionCriteria",
+      "@container": "@set"
+    },
+    "exclusion_criteria": {
+      "@id": "behaverse:exclusionCriteria",
+      "@container": "@set"
+    },
+    "datasets": {
+      "@id": "https://schema.org/hasPart",
+      "@container": "@set"
+    },
+    "dataset_count": {
+      "@id": "behaverse:datasetCount",
+      "@type": "xsd:integer"
+    },
+    "related_collections": {
+      "@id": "behaverse:relatedCollections",
+      "@container": "@set"
+    },
+    "date_created": {
+      "@id": "https://schema.org/dateCreated",
+      "@type": "xsd:date"
+    },
+    "date_modified": {
+      "@id": "https://schema.org/dateModified",
+      "@type": "xsd:date"
+    },
+    "curator": {
+      "@id": "https://schema.org/curator",
+      "@container": "@set"
+    }
+  }
+}

--- a/catalog/versions/v25.1202/schema.json
+++ b/catalog/versions/v25.1202/schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://behaverse.org/schemas/collection/v25.1202/schema.json",
+  "title": "Behaverse Collection Schema",
+  "description": "A metadata schema for thematic collections of cognitive science and neuroscience datasets",
+  "version": "25.1202",
+  "type": "object",
+  "required": [
+    "name",
+    "pretty_name",
+    "description",
+    "inclusion_criteria"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "description": "Short URL-friendly identifier",
+      "equivalentProperty": "https://schema.org/name",
+      "pattern": "^[a-z0-9-_]+$"
+    },
+    "pretty_name": {
+      "type": "string",
+      "title": "Pretty Name",
+      "description": "Human-readable display title",
+      "equivalentProperty": "https://schema.org/name"
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "Comprehensive description of the collection's purpose and scope",
+      "equivalentProperty": [
+        "https://schema.org/description",
+        "http://purl.org/dc/terms/description"
+      ]
+    },
+    "keywords": {
+      "type": "array",
+      "title": "Keywords",
+      "description": "Keywords describing the collection's focus areas",
+      "equivalentProperty": "https://schema.org/keywords",
+      "items": {
+        "type": "string"
+      }
+    },
+    "inclusion_criteria": {
+      "type": "array",
+      "title": "Inclusion Criteria",
+      "description": "Specific rules a dataset must meet to be included in this collection (all criteria must be met)",
+      "equivalentProperty": "https://behaverse.org/schemas/collection#inclusionCriteria",
+      "items": {
+        "type": "string"
+      }
+    },
+    "exclusion_criteria": {
+      "type": "array",
+      "title": "Exclusion Criteria",
+      "description": "Criteria that would exclude a dataset from this collection",
+      "equivalentProperty": "https://behaverse.org/schemas/collection#exclusionCriteria",
+      "items": {
+        "type": "string"
+      }
+    },
+    "datasets": {
+      "type": "array",
+      "title": "Datasets",
+      "description": "List of dataset URLs or DOIs that belong to this collection (use stable identifiers like DOIs or canonical URLs)",
+      "equivalentProperty": "https://schema.org/hasPart",
+      "format": "uri",
+      "items": {
+        "type": "string"
+      }
+    },
+    "dataset_count": {
+      "type": "integer",
+      "title": "Dataset Count",
+      "description": "Number of datasets currently in this collection",
+      "equivalentProperty": "https://behaverse.org/schemas/collection#datasetCount"
+    },
+    "related_collections": {
+      "type": "array",
+      "title": "Related Collections",
+      "description": "Names of other collections that frequently overlap with this one",
+      "equivalentProperty": "https://behaverse.org/schemas/collection#relatedCollections",
+      "items": {
+        "type": "string"
+      }
+    },
+    "date_created": {
+      "type": "string",
+      "title": "Date Created",
+      "description": "Date this collection was created (ISO 8601)",
+      "equivalentProperty": "https://schema.org/dateCreated",
+      "format": "date"
+    },
+    "date_modified": {
+      "type": "string",
+      "title": "Date Modified",
+      "description": "Date this collection definition was last modified (ISO 8601)",
+      "equivalentProperty": "https://schema.org/dateModified",
+      "format": "date"
+    },
+    "curator": {
+      "type": "array",
+      "title": "Curator",
+      "description": "People or organizations that curate this collection",
+      "equivalentProperty": "https://schema.org/curator",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Curator full name"
+          },
+          "email": {
+            "type": "string",
+            "description": "Curator email address",
+            "format": "email"
+          },
+          "orcid": {
+            "type": "string",
+            "description": "ORCID identifier",
+            "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"
+          },
+          "affiliation": {
+            "type": "string",
+            "description": "Institutional affiliation"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/event/versions/v26.0608/context.jsonld
+++ b/event/versions/v26.0608/context.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab":     "https://behaverse.org/schemas/event#",
+    "bdm":        "https://behaverse.org/data-model/vocab/",
+    "xapi":       "https://w3id.org/xapi/",
+    "schema":     "http://schema.org/",
+    "as2":        "https://www.w3.org/ns/activitystreams#",
+    "actor":      { "@id": "https://behaverse.org/data-model/vocab/actor" },
+    "verb":       { "@id": "https://behaverse.org/data-model/vocab/verb", "@type": "@id" },
+    "object":     { "@id": "https://behaverse.org/data-model/vocab/object" },
+    "objectType": { "@id": "@type" },
+    "result":     { "@id": "https://behaverse.org/data-model/vocab/result" },
+    "context":    { "@id": "https://behaverse.org/data-model/vocab/context" },
+    "extensions": { "@id": "https://behaverse.org/data-model/vocab/extensions" },
+    "events":     { "@id": "https://behaverse.org/schemas/event#events", "@container": "@list" }
+  }
+}

--- a/event/versions/v26.0608/field-definitions.json
+++ b/event/versions/v26.0608/field-definitions.json
@@ -1,0 +1,368 @@
+{
+  "schema": "event",
+  "version": "26.0608",
+  "namespace": "https://behaverse.org/schemas/event",
+  "description": "Raw experimental events for cognitive tests, questionnaires, and games. An xAPI-style envelope (actor / verb / object) carrying a single canonical `bdm:` vocabulary, so one set of analytics tooling can process every domain. Continuous signals (mouse, keyboard, EEG) are referenced via attachments, not inlined.",
+  "fields": [
+    {
+      "name": "actor",
+      "type": "object",
+      "requirement": "required",
+      "description": "Who or what performed/experienced the event — `{objectType, id, name?}`, where objectType is one of the actor types below. (Renamed from `agent`; an Agent is one type of actor — BDM deviation D5.)"
+    },
+    {
+      "name": "verb",
+      "type": "string",
+      "requirement": "required",
+      "description": "The action that occurred, drawn from the canonical verb vocabulary below."
+    },
+    {
+      "name": "object",
+      "type": "object",
+      "requirement": "required",
+      "description": "What the action was performed on — `{objectType, id, name?}`, where objectType is one of the object types below."
+    },
+    {
+      "name": "timestamp",
+      "type": "datetime (RFC 9557)",
+      "requirement": "required",
+      "description": "When the event occurred, as an ISO 8601 / RFC 9557 datetime with timezone offset."
+    },
+    {
+      "name": "result",
+      "type": "object",
+      "requirement": "optional",
+      "description": "The outcome of the event (e.g. accuracy, response_time, score). Domain-specific payload lives under `result.extensions` keyed by `bdm:*` extension keys."
+    },
+    {
+      "name": "context",
+      "type": "object",
+      "requirement": "optional",
+      "description": "Contextual information (study, studyflow, and the session→activity→runtime→block→trial scoping hierarchy) under `context.extensions`, keyed by `bdm:*` extension keys."
+    },
+    {
+      "name": "version",
+      "type": "string",
+      "requirement": "optional",
+      "description": "The associated BDM/schema version (e.g. `v26.0608`). Typically populated by the LRS."
+    },
+    {
+      "name": "stored",
+      "type": "datetime (RFC 9557)",
+      "requirement": "optional",
+      "description": "When the event was stored in the LRS. Populated by the LRS."
+    },
+    {
+      "name": "updated",
+      "type": "datetime (RFC 9557)",
+      "requirement": "optional",
+      "description": "When the event was last updated in the LRS. Populated by the LRS."
+    },
+    {
+      "name": "authority",
+      "type": "object",
+      "requirement": "optional",
+      "description": "The authority that generated the event (e.g. the client app/developer). Populated by the LRS."
+    },
+    {
+      "name": "attachments",
+      "type": "array",
+      "requirement": "optional",
+      "description": "References to additional files/data associated with the event (stimulus blobs, recording files, timeseries), each with its own metadata. Payloads are not inlined."
+    }
+  ],
+  "vocabularies": {
+    "verbs": [
+      {
+        "name": "bdm:initialized",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance record minted; instrument loaded; engine ready. Nothing shown yet."
+      },
+      {
+        "name": "bdm:started",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "First content actually shown to the participant; starts the experiential clock."
+      },
+      {
+        "name": "bdm:paused",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance suspended (extended visibility loss, idle threshold, or explicit pause)."
+      },
+      {
+        "name": "bdm:resumed",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance continued after a pause. Carries bdm:pause_duration."
+      },
+      {
+        "name": "bdm:completed",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "All required content done. Distinct from submitted."
+      },
+      {
+        "name": "bdm:submitted",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "Data left the engine (POST to Orchestrator acknowledged)."
+      },
+      {
+        "name": "bdm:abandoned",
+        "object_types": [
+          "bdm:RuntimeInstance"
+        ],
+        "layer": "lifecycle",
+        "description": "RuntimeInstance ended without completion. Carries bdm:abandon_reason."
+      },
+      {
+        "name": "bdm:presented",
+        "object_types": [
+          "bdm:Screen",
+          "bdm:Panel",
+          "bdm:Stimulus",
+          "bdm:Option",
+          "bdm:Feedback",
+          "bdm:ConsentForm"
+        ],
+        "layer": "presentation",
+        "description": "Something became perceivable (rendered or played). Typically the response-time anchor for Stimulus/Option."
+      },
+      {
+        "name": "bdm:clicked",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "Pointer click (mouse, tap, stylus); the lowest-level click event."
+      },
+      {
+        "name": "bdm:drag_and_dropped",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "A drag-and-drop gesture completed. Carries bdm:drag_source and bdm:drop_target."
+      },
+      {
+        "name": "bdm:key_pressed",
+        "object_types": [
+          "bdm:UIComponent",
+          "bdm:Stimulus"
+        ],
+        "layer": "interaction",
+        "description": "A single key event. Carries bdm:key and bdm:key_code."
+      },
+      {
+        "name": "bdm:typed",
+        "object_types": [
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "A text input was committed (debounced). Carries bdm:typed_text and bdm:key_sequence."
+      },
+      {
+        "name": "bdm:selected",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "Discrete option selected (radio, checkbox, dropdown)."
+      },
+      {
+        "name": "bdm:deselected",
+        "object_types": [
+          "bdm:Option",
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "Discrete option deselected (e.g. checkbox unchecked)."
+      },
+      {
+        "name": "bdm:adjusted",
+        "object_types": [
+          "bdm:UIComponent"
+        ],
+        "layer": "interaction",
+        "description": "A continuous-value control was set (slider, spinner, dial). Carries bdm:current_value."
+      },
+      {
+        "name": "bdm:got_focus",
+        "object_types": [
+          "bdm:UIComponent",
+          "bdm:Window"
+        ],
+        "layer": "interaction",
+        "description": "Focus gained by an input control or by the runtime window/tab."
+      },
+      {
+        "name": "bdm:lost_focus",
+        "object_types": [
+          "bdm:UIComponent",
+          "bdm:Window"
+        ],
+        "layer": "interaction",
+        "description": "Focus lost. Window-level loss may (by threshold) lead to bdm:paused."
+      },
+      {
+        "name": "bdm:consented",
+        "object_types": [
+          "bdm:Consent"
+        ],
+        "layer": "interaction",
+        "description": "The agent committed to consent. Carries bdm:consent_text_hash and bdm:consent_scope."
+      },
+      {
+        "name": "bdm:trial_started",
+        "object_types": [
+          "bdm:Trial"
+        ],
+        "layer": "system",
+        "description": "A trial began. Carries bdm:trial_index and (when applicable) bdm:block_index / bdm:block_type."
+      },
+      {
+        "name": "bdm:trial_ended",
+        "object_types": [
+          "bdm:Trial"
+        ],
+        "layer": "system",
+        "description": "Trial finalised; a Response (trial) row is created. Carries the canonical response_*, response_time, correct/score, and bdm:response_id. Exactly one per trial."
+      },
+      {
+        "name": "bdm:state_changed",
+        "object_types": [
+          "bdm:Timer",
+          "bdm:Scorer",
+          "bdm:LocaleSwitch"
+        ],
+        "layer": "system",
+        "description": "A software-internal state change not tied to a presentation (timer, scorer, locale switch)."
+      },
+      {
+        "name": "bdm:recording_started",
+        "object_types": [
+          "bdm:Recording"
+        ],
+        "layer": "recording",
+        "description": "A continuous-data recording opened. Carries bdm:source and bdm:sample_rate."
+      },
+      {
+        "name": "bdm:recording_ended",
+        "object_types": [
+          "bdm:Recording"
+        ],
+        "layer": "recording",
+        "description": "A recording closed and was stored. Carries bdm:recording_url, bdm:recording_sha256, bdm:duration."
+      },
+      {
+        "name": "bdm:navigated",
+        "object_types": [
+          "bdm:Screen"
+        ],
+        "layer": "navigation",
+        "description": "Participant moved between Screens. Carries bdm:from_screen_id and bdm:to_screen_id."
+      }
+    ],
+    "object_types": [
+      {
+        "name": "bdm:RuntimeInstance",
+        "description": "One specific runtime execution of an Activity (distinguishes restarts)."
+      },
+      {
+        "name": "bdm:Screen",
+        "description": "One screen unit (questionnaire page, instructions screen, trial screen)."
+      },
+      {
+        "name": "bdm:Panel",
+        "description": "A within-screen layout grouping (e.g. matrix rows)."
+      },
+      {
+        "name": "bdm:Stimulus",
+        "description": "A displayed/audible thing the participant perceives within a trial."
+      },
+      {
+        "name": "bdm:Option",
+        "description": "A response option shown to the participant (radio, checkbox, dropdown entry)."
+      },
+      {
+        "name": "bdm:Trial",
+        "description": "The participant-administered unit; one Response (trial) row per Trial."
+      },
+      {
+        "name": "bdm:UIComponent",
+        "description": "An interactive UI control (radio, checkbox, slider, text field, button, key listener)."
+      },
+      {
+        "name": "bdm:Window",
+        "description": "The runtime window or browser tab (system-wide focus context)."
+      },
+      {
+        "name": "bdm:Feedback",
+        "description": "A post-response feedback display (correctness, score, band label, explanation)."
+      },
+      {
+        "name": "bdm:ConsentForm",
+        "description": "The consent form presented for review (what was shown)."
+      },
+      {
+        "name": "bdm:Consent",
+        "description": "The consent record — the audit entity capturing the agreement (what was committed to)."
+      },
+      {
+        "name": "bdm:Recording",
+        "description": "A continuous-data capture record (mouse, keyboard, EEG, …)."
+      },
+      {
+        "name": "bdm:Timer",
+        "description": "An internal software timer (trial timeout, idle detector)."
+      },
+      {
+        "name": "bdm:Scorer",
+        "description": "A Scorer entity invocation."
+      },
+      {
+        "name": "bdm:LocaleSwitch",
+        "description": "A programmatic locale change."
+      }
+    ],
+    "actor_types": [
+      {
+        "name": "bdm:Agent",
+        "description": "A specific agent — usually the human participant; may be an AI/automated participant."
+      },
+      {
+        "name": "bdm:Group",
+        "description": "A collection of agents acting together (xAPI compatibility; rare)."
+      },
+      {
+        "name": "bdm:Engine",
+        "description": "The runtime software acting on its own (web viewer, Godot viewer, game engine, CLI runner)."
+      },
+      {
+        "name": "bdm:Orchestrator",
+        "description": "The backend service that schedules Activities, mints RuntimeInstances, manages submission."
+      },
+      {
+        "name": "bdm:Researcher",
+        "description": "A researcher acting on the data (post-hoc annotation/correction)."
+      }
+    ]
+  }
+}

--- a/event/versions/v26.0608/schema.json
+++ b/event/versions/v26.0608/schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://behaverse.org/schemas/event/v26.0608/schema.json",
+  "version": "26.0608",
+  "title": "Behaverse Event Data (BDM Events extension)",
+  "description": "Per OD-19 (resolved 2026-06-05), BDM Events vocabulary covering questionnaires, cognitive tasks, and video games under a single bdm: namespace.",
+  "oneOf": [
+    { "$ref": "#/$defs/Event" },
+    { "$ref": "#/$defs/EventBatch" }
+  ],
+  "$defs": {
+    "Event": {
+      "type": "object",
+      "required": ["actor", "verb", "object", "timestamp"],
+      "properties": {
+        "version":    { "type": "string", "pattern": "^v\\d{2}\\.\\d{4}$" },
+        "timestamp":  { "type": "string", "format": "date-time" },
+        "stored":     { "type": "string", "format": "date-time" },
+        "updated":    { "type": "string", "format": "date-time" },
+        "actor":      { "$ref": "#/$defs/Actor" },
+        "verb":       { "$ref": "#/$defs/Verb" },
+        "object":     { "$ref": "#/$defs/EventObject" },
+        "result":     { "$ref": "#/$defs/Result" },
+        "context":    { "$ref": "#/$defs/Context" },
+        "authority":  { "type": "object" },
+        "attachments":{ "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false,
+      "patternProperties": { "^x_": {} }
+    },
+    "EventBatch": {
+      "type": "object",
+      "required": ["events"],
+      "properties": {
+        "batch_id": { "type": "string" },
+        "events":   { "type": "array", "items": { "$ref": "#/$defs/Event" }, "minItems": 1 }
+      },
+      "additionalProperties": false,
+      "patternProperties": { "^x_": {} }
+    },
+    "Actor": {
+      "type": "object",
+      "required": ["objectType", "id"],
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "enum": ["bdm:Agent", "bdm:Group", "bdm:Engine", "bdm:Orchestrator", "bdm:Researcher"]
+        },
+        "id":   { "type": "string" },
+        "name": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "Verb": {
+      "type": "string",
+      "enum": [
+        "bdm:initialized", "bdm:started", "bdm:paused", "bdm:resumed",
+        "bdm:completed", "bdm:submitted", "bdm:abandoned",
+        "bdm:presented",
+        "bdm:clicked", "bdm:drag_and_dropped", "bdm:key_pressed", "bdm:typed",
+        "bdm:selected", "bdm:deselected", "bdm:adjusted",
+        "bdm:got_focus", "bdm:lost_focus", "bdm:consented",
+        "bdm:trial_started", "bdm:trial_ended", "bdm:state_changed",
+        "bdm:recording_started", "bdm:recording_ended",
+        "bdm:navigated"
+      ]
+    },
+    "EventObject": {
+      "type": "object",
+      "required": ["objectType", "id"],
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "enum": [
+            "bdm:RuntimeInstance", "bdm:Screen", "bdm:Panel", "bdm:Stimulus",
+            "bdm:Option", "bdm:Trial", "bdm:UIComponent", "bdm:Window",
+            "bdm:Feedback", "bdm:ConsentForm", "bdm:Consent",
+            "bdm:Recording", "bdm:Timer", "bdm:Scorer", "bdm:LocaleSwitch"
+          ]
+        },
+        "id":   { "type": "string" },
+        "name": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "Result": {
+      "type": "object",
+      "properties": {
+        "extensions": { "$ref": "#/$defs/BDMExtensions" }
+      },
+      "additionalProperties": true
+    },
+    "Context": {
+      "type": "object",
+      "properties": {
+        "extensions": { "$ref": "#/$defs/BDMExtensions" }
+      },
+      "additionalProperties": true
+    },
+    "BDMExtensions": {
+      "type": "object",
+      "patternProperties": {
+        "^bdm:[a-z][a-z0-9_]*$": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Phase 3 process hardening (three of item 10's four parts; git tags follow after merge so they can point at merged main).

- **CI guard**: new `versions-immutable` job in `validate-schemas.yml` — PRs may add snapshot files, never modify or delete them. The immutability policy VERSIONING.md promises is now mechanical. (PR-only; `workflow_call` from deploy-on-main skips it, as there is no base to diff.)
- **Stability contract**: VERSIONING.md's pinning section gains "What consumers may rely on" — enforced immutability, pinned-snapshot permanence, unversioned-URLs-track-main, changelog `### Breaking` as the sole compatibility signal, and `<family>-v<VERSION>` git tags.
- **Snapshot backfill** (the two releases OPEN §3 records as published-but-never-archived): `event/versions/v26.0608/` (schema.json + context + field-definitions, from the commit that added the version field) and `catalog/versions/v25.1202/` — recoverable only as the pre-rename **collection** artifact, archived **verbatim** with a README stating the provenance, because that is faithfully what v25.1202 was.

Once merged I'll backfill annotated tags `<family>-v<VERSION>` for every snapshot (pointing at the commit that introduced each one) and tag current releases. This PR should also demonstrate its own guard passing (it only adds under versions/).