### PR TITLE
chore: CITATION.cff, scripts/ MIT license, runnable validation command in every README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use the Behaverse schemas, please cite the paper in 'preferred-citation'."
+title: "Behaverse Schemas"
+abstract: "Machine-readable schemas for the Behaverse Data Model: trial, event, timeseries, studyflow, agents, dataset, catalog, bcsv, and the shared vocabulary."
+type: software
+url: "https://behaverse.org/schemas"
+repository-code: "https://github.com/behaverse/schemas"
+license: CC-BY-4.0
+authors:
+  - family-names: Cardoso-Leite
+    given-names: Pedro
+  - family-names: Ansarinia
+    given-names: Morteza
+preferred-citation:
+  type: article
+  title: "The structure of behavioral data"
+  year: 2020
+  url: "https://arxiv.org/abs/2012.12583"
+  identifiers:
+    - type: other
+      value: "arXiv:2012.12583"
+  authors:
+    - family-names: Defossez
+      given-names: Aurélien
+    - family-names: Ansarinia
+      given-names: Morteza
+    - family-names: Clocher
+      given-names: Brice
+    - family-names: Schmück
+      given-names: Emmanuel
+    - family-names: Schrater
+      given-names: Paul
+    - family-names: Cardoso-Leite
+      given-names: Pedro

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ behaverse/schemas/                 # (main branch)
 
 ## License
 
-These schemas are licensed under [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+The schema content is licensed under [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/). The tooling under [`scripts/`](scripts/) is licensed under [MIT](scripts/LICENSE), matching the `license: MIT` the LinkML sources declare.
 
 You are free to:
 - **Share**: Copy and redistribute the schemas

--- a/bcsv/README.md
+++ b/bcsv/README.md
@@ -298,3 +298,16 @@ This schema is licensed under [Creative Commons Attribution 4.0 International (C
 ## AI Usage Disclosure 
 
 This document was created with assistance from AI tools.
+
+## Validating a document
+
+`schema.json` is a standard JSON Schema; any validator works. From a repo checkout
+(requires `pip install jsonschema`), validating the shipped example:
+
+```bash
+python3 -c "import json, jsonschema; jsonschema.validate(json.load(open('bcsv/examples/measurements.json')), json.load(open('bcsv/schema.json')))"
+```
+
+Substitute your own document for the example to validate real data. The published
+schema is at `https://behaverse.org/schemas/bcsv/schema.json` (pin a
+`versions/v<VERSION>/` URL for production use — see [`../VERSIONING.md`](../VERSIONING.md)).

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -304,3 +304,16 @@ This schema and documentation were developed with the assistance of AI tools (Gi
 **License**: CC-BY-4.0  
 **Maintainer**: Behaverse Project  
 **Repository**: https://github.com/behaverse/schemas
+
+## Validating a document
+
+`schema.json` is a standard JSON Schema; any validator works. From a repo checkout
+(requires `pip install jsonschema`), validating the shipped example:
+
+```bash
+python3 -c "import json, jsonschema; jsonschema.validate(json.load(open('dataset/examples/demo-dataset.json')), json.load(open('dataset/schema.json')))"
+```
+
+Substitute your own document for the example to validate real data. The published
+schema is at `https://behaverse.org/schemas/dataset/schema.json` (pin a
+`versions/v<VERSION>/` URL for production use — see [`../VERSIONING.md`](../VERSIONING.md)).

--- a/event/README.md
+++ b/event/README.md
@@ -55,3 +55,16 @@ Relocated from the Behaverse questionnaire project (`schemas/events`, v26.0605),
 ## Versioning
 
 CalVer `vYY.MMDD`. See the repo-wide [`VERSIONING.md`](../VERSIONING.md).
+
+## Validating a document
+
+`schema.json` is a standard JSON Schema; any validator works. From a repo checkout
+(requires `pip install jsonschema`), validating the shipped example:
+
+```bash
+python3 -c "import json, jsonschema; jsonschema.validate(json.load(open('event/examples/minimal_event.json')), json.load(open('event/schema.json')))"
+```
+
+Substitute your own document for the example to validate real data. The published
+schema is at `https://behaverse.org/schemas/event/schema.json` (pin a
+`versions/v<VERSION>/` URL for production use — see [`../VERSIONING.md`](../VERSIONING.md)).

--- a/scripts/LICENSE
+++ b/scripts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 xCIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/studyflow/README.md
+++ b/studyflow/README.md
@@ -25,3 +25,15 @@ For detailed documentation, visit the [Studyflow Documentation](https://behavers
 | [`schema.linkml.yaml`](schema.linkml.yaml) | ✅ | Source of truth (LinkML). Edit it, then run `python scripts/generate.py`. |
 | [`schema.json`](schema.json) | ✅ generated | JSON Schema validation contract for a studyflow document. |
 | [`field-definitions.json`](field-definitions.json) | ✅ generated | Render contract, so the documentation sites can generate this family's reference instead of describing it by hand. |
+
+## Validating a document
+
+`schema.json` is a standard JSON Schema validating a JSON studyflow document; any validator works
+(requires `pip install jsonschema`):
+
+```bash
+python3 -c "import json, jsonschema; jsonschema.validate(json.load(open('YOUR_DOCUMENT.json')), json.load(open('studyflow/schema.json')))"
+```
+
+The published schema is at `https://behaverse.org/schemas/studyflow/schema.json` (pin a
+`versions/v<VERSION>/` URL for production use — see [`../VERSIONING.md`](../VERSIONING.md)).

--- a/timeseries/README.md
+++ b/timeseries/README.md
@@ -46,3 +46,16 @@ Channels `t` (float, `s`) + `x` + `y` (float, one `coordinate_frame` ∈ `screen
 ## Versioning
 
 CalVer `vYY.MMDD`. See the repo-wide [`VERSIONING.md`](../VERSIONING.md).
+
+## Validating a document
+
+`schema.json` is a standard JSON Schema; any validator works. From a repo checkout
+(requires `pip install jsonschema`), validating the shipped example:
+
+```bash
+python3 -c "import json, jsonschema; jsonschema.validate(json.load(open('timeseries/examples/mouse_1.ndjson.gz.timeseries.json')), json.load(open('timeseries/schema.json')))"
+```
+
+Substitute your own document for the example to validate real data. The published
+schema is at `https://behaverse.org/schemas/timeseries/schema.json` (pin a
+`versions/v<VERSION>/` URL for production use — see [`../VERSIONING.md`](../VERSIONING.md)).

--- a/trial/README.md
+++ b/trial/README.md
@@ -61,3 +61,15 @@ Relocated from `behaverse/data-model` (where it was generated from a Google Shee
 ## Versioning
 
 CalVer `vYY.MMDD`. See the repo-wide [`VERSIONING.md`](../VERSIONING.md).
+
+## Validating a document
+
+`schema.json` is a standard JSON Schema validating a JSON document mapping table names to arrays of row objects (e.g. `{"Response": [...]}`); any validator works
+(requires `pip install jsonschema`):
+
+```bash
+python3 -c "import json, jsonschema; jsonschema.validate(json.load(open('YOUR_DOCUMENT.json')), json.load(open('trial/schema.json')))"
+```
+
+The published schema is at `https://behaverse.org/schemas/trial/schema.json` (pin a
+`versions/v<VERSION>/` URL for production use — see [`../VERSIONING.md`](../VERSIONING.md)).


### PR DESCRIPTION
Phase 3 packaging round.

- **CITATION.cff** — mirrors data-model's (same author list and preferred citation), with title/URLs for this repo.
- **License split** — root LICENSE stays CC BY 4.0 for the schema content; `scripts/LICENSE` (MIT) now covers the tooling, and the root README's License section states the split. The LinkML sources already declared `license: MIT`, so this records existing intent rather than changing it. **Please confirm the copyright line** — I used "Copyright (c) 2026 xCIT" from the site footer.
- **Validation commands** — every family README with a `schema.json` now shows a runnable command (previously only catalog's did). Families that ship examples validate one; **each such command was executed and passes** (bcsv, dataset, event, timeseries). trial/studyflow use a your-document placeholder and state the expected document shape. Each snippet also points at the published URL and the pin-for-production advice.